### PR TITLE
Drop support for Python 3.8 and 3.9

### DIFF
--- a/.github/update-environment.py
+++ b/.github/update-environment.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import TYPE_CHECKING
 
 import tomllib
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 PIP_ONLY_DEPS: set[str] = set()
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/docs/environment-sphinx.yml
+++ b/docs/environment-sphinx.yml
@@ -11,7 +11,6 @@ dependencies:
   - networkx
   - psutil
   - versioningit
-  - typing_extensions
   - cloudpickle
   - numpy
   # optional-dependencies: xarray

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - networkx
   - psutil
   - versioningit
-  - typing_extensions
   - cloudpickle
   - numpy
   # optional-dependencies: xarray

--- a/pipefunc/_cache.py
+++ b/pipefunc/_cache.py
@@ -6,7 +6,7 @@ import pickle
 from contextlib import nullcontext, suppress
 from multiprocessing import Manager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Hashable
+from typing import TYPE_CHECKING, Any
 
 import cloudpickle
 

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -17,8 +17,8 @@ import datetime
 import functools
 import inspect
 import os
-import sys
-from typing import TYPE_CHECKING, Any, Generic, Tuple, TypeVar, Union
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar, Union
 
 import cloudpickle
 
@@ -27,22 +27,12 @@ from pipefunc._utils import at_least_tuple, clear_cached_properties, format_func
 from pipefunc.lazy import evaluate_lazy
 from pipefunc.map._mapspec import MapSpec
 
-if sys.version_info < (3, 9):  # pragma: no cover
-    from typing import Callable
-else:
-    from collections.abc import Callable
-
 if TYPE_CHECKING:
     from pathlib import Path
 
-    if sys.version_info < (3, 10):  # pragma: no cover
-        from typing_extensions import TypeAlias
-    else:
-        from typing import TypeAlias
-
 
 T = TypeVar("T", bound=Callable[..., Any])
-_OUTPUT_TYPE: TypeAlias = Union[str, Tuple[str, ...]]
+_OUTPUT_TYPE: TypeAlias = Union[str, tuple[str, ...]]
 MAX_PARAMS_LEN = 15
 
 

--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -17,7 +17,7 @@ import inspect
 import time
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Iterable, Literal, NamedTuple, Tuple, Union
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeAlias, Union
 
 import networkx as nx
 
@@ -44,7 +44,7 @@ from pipefunc.map._mapspec import (
 from pipefunc.map._run import run
 
 if TYPE_CHECKING:
-    import sys
+    from collections.abc import Callable, Iterable
     from concurrent.futures import Executor
     from pathlib import Path
 
@@ -53,19 +53,9 @@ if TYPE_CHECKING:
     from pipefunc._perf import ProfilingStats
     from pipefunc.map._run import Result
 
-    if sys.version_info < (3, 10):  # pragma: no cover
-        from typing_extensions import TypeAlias
-    else:
-        from typing import TypeAlias
 
-    if sys.version_info < (3, 9):  # pragma: no cover
-        from typing import Callable
-    else:
-        from collections.abc import Callable
-
-
-_OUTPUT_TYPE: TypeAlias = Union[str, Tuple[str, ...]]
-_CACHE_KEY_TYPE: TypeAlias = Tuple[_OUTPUT_TYPE, Tuple[Tuple[str, Any], ...]]
+_OUTPUT_TYPE: TypeAlias = Union[str, tuple[str, ...]]
+_CACHE_KEY_TYPE: TypeAlias = tuple[_OUTPUT_TYPE, tuple[tuple[str, Any], ...]]
 
 
 class _Function:

--- a/pipefunc/_simplify.py
+++ b/pipefunc/_simplify.py
@@ -3,32 +3,22 @@ from __future__ import annotations
 import inspect
 import warnings
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Tuple, Union
+from typing import TYPE_CHECKING, Any, TypeAlias, Union
 
 import networkx as nx
 
 from pipefunc._utils import at_least_tuple
 
 if TYPE_CHECKING:
-    import sys
+    from collections.abc import Callable
 
     import networkx as nx
 
     from pipefunc._pipefunc import PipeFunc
     from pipefunc._pipeline import Pipeline
 
-    if sys.version_info < (3, 10):  # pragma: no cover
-        from typing_extensions import TypeAlias
-    else:
-        from typing import TypeAlias
 
-    if sys.version_info < (3, 9):  # pragma: no cover
-        from typing import Callable
-    else:
-        from collections.abc import Callable
-
-
-_OUTPUT_TYPE: TypeAlias = Union[str, Tuple[str, ...]]
+_OUTPUT_TYPE: TypeAlias = Union[str, tuple[str, ...]]
 
 
 def _wrap_dict_to_tuple(

--- a/pipefunc/_utils.py
+++ b/pipefunc/_utils.py
@@ -9,10 +9,13 @@ import operator
 import sys
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import TYPE_CHECKING, Any
 
 import cloudpickle
 import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
 
 
 def at_least_tuple(x: Any) -> tuple[Any, ...]:

--- a/pipefunc/lazy.py
+++ b/pipefunc/lazy.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Any, Generator, Iterable, NamedTuple
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import networkx as nx
 
@@ -11,12 +12,7 @@ from pipefunc._cache import SimpleCache
 from pipefunc._utils import format_function_call
 
 if TYPE_CHECKING:
-    import sys
-
-    if sys.version_info < (3, 9):  # pragma: no cover
-        from typing import Callable
-    else:
-        from collections.abc import Callable
+    from collections.abc import Callable, Generator
 
 
 class _LazyFunction:

--- a/pipefunc/map/_dictarray.py
+++ b/pipefunc/map/_dictarray.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import itertools
 import multiprocessing
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, MutableMapping
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -18,6 +18,7 @@ from pipefunc.map._storage_base import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
     from multiprocessing.managers import DictProxy
 
 

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -8,7 +8,7 @@ from concurrent.futures import Executor, ProcessPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Generator, NamedTuple, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -21,27 +21,18 @@ from pipefunc.map._mapspec import (
     validate_consistent_axes,
 )
 from pipefunc.map._run_info import RunInfo, _external_shape, _internal_shape, _load_input
-from pipefunc.map._storage_base import (
-    StorageBase,
-    _iterate_shape_indices,
-    _select_by_mask,
-)
+from pipefunc.map._storage_base import StorageBase, _iterate_shape_indices, _select_by_mask
 
 if TYPE_CHECKING:
-    import sys
+    from collections.abc import Callable, Generator, Sequence
 
     import xarray as xr
 
     from pipefunc import PipeFunc, Pipeline
     from pipefunc._pipeline import _Generations
 
-    if sys.version_info < (3, 10):  # pragma: no cover
-        from typing_extensions import TypeAlias
-    else:
-        from typing import TypeAlias
 
-
-_OUTPUT_TYPE: TypeAlias = Union[str, Tuple[str, ...]]
+_OUTPUT_TYPE: TypeAlias = Union[str, tuple[str, ...]]
 
 
 @dataclass

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -5,7 +5,7 @@ import json
 import shutil
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple, Tuple, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, Union
 
 from pipefunc._utils import at_least_tuple, dump, equal_dicts, load
 from pipefunc._version import __version__
@@ -13,16 +13,9 @@ from pipefunc.map._mapspec import MapSpec, array_shape
 from pipefunc.map._storage_base import StorageBase, storage_registry
 
 if TYPE_CHECKING:
-    import sys
-
     from pipefunc import Pipeline
 
-    if sys.version_info < (3, 10):  # pragma: no cover
-        from typing_extensions import TypeAlias
-    else:
-        from typing import TypeAlias
-
-_OUTPUT_TYPE: TypeAlias = Union[str, Tuple[str, ...]]
+_OUTPUT_TYPE: TypeAlias = Union[str, tuple[str, ...]]
 
 
 class Shapes(NamedTuple):

--- a/pipefunc/map/adaptive.py
+++ b/pipefunc/map/adaptive.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, Tuple, Union
+from typing import TYPE_CHECKING, Any, TypeAlias, Union
 
 import numpy as np
 from adaptive import SequenceLearner
@@ -28,7 +28,7 @@ from pipefunc.map._run_info import RunInfo, map_shapes
 from pipefunc.map._storage_base import _iterate_shape_indices
 
 if TYPE_CHECKING:
-    import sys
+    from collections.abc import Generator
 
     import numpy.typing as npt
 
@@ -36,13 +36,8 @@ if TYPE_CHECKING:
     from pipefunc.map._storage_base import StorageBase
     from pipefunc.sweep import Sweep
 
-    if sys.version_info < (3, 10):  # pragma: no cover
-        from typing_extensions import TypeAlias
-    else:
-        from typing import TypeAlias
 
-
-_OUTPUT_TYPE: TypeAlias = Union[str, Tuple[str, ...]]
+_OUTPUT_TYPE: TypeAlias = Union[str, tuple[str, ...]]
 
 
 def create_learners(

--- a/pipefunc/sweep.py
+++ b/pipefunc/sweep.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Hashable, Iterable
 from itertools import product
-from typing import TYPE_CHECKING, Any, Callable, Generator, Hashable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 
 from pipefunc._utils import at_least_tuple
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Iterator, Mapping, Sequence
+
     from pipefunc._pipeline import _OUTPUT_TYPE, PipeFunc, Pipeline
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools", "wheel", "versioningit"]
 [project]
 name = "pipefunc"
 description = "A Python library for defining, managing, and executing function pipelines."
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dynamic = ["version"]
 maintainers = [{ name = "Bas Nijholt", email = "bas@nijho.lt" }]
 license = { text = "MIT" }
@@ -17,8 +17,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -29,7 +27,6 @@ dependencies = [
     "networkx",
     "psutil",
     "versioningit",
-    "typing_extensions; python_version <= '3.9'",
     "cloudpickle",
     "numpy",
 ]
@@ -107,7 +104,7 @@ omit = ["pipefunc/_plotting.py"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -140,4 +137,4 @@ ignore = [
 max-complexity = 18
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"

--- a/tests/map/test_base_filearray.py
+++ b/tests/map/test_base_filearray.py
@@ -1,5 +1,6 @@
-from pathlib import Path
-from typing import Callable
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -10,6 +11,10 @@ from pipefunc.map._dictarray import DictArray
 from pipefunc.map._filearray import FileArray
 from pipefunc.map._storage_base import StorageBase, _iterate_shape_indices, _select_by_mask
 from pipefunc.map.zarr import ZarrFileArray
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
 
 
 @pytest.fixture(params=["file_array", "zarr_array", "dict"])

--- a/tests/map/test_filearray.py
+++ b/tests/map/test_filearray.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np

--- a/tests/map/test_mapspec.py
+++ b/tests/map/test_mapspec.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 import numpy as np

--- a/tests/map/test_zarr.py
+++ b/tests/map/test_zarr.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import zarr
 

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 
 import networkx as nx

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pipefunc._perf import ResourceStats
 
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from itertools import product
 
 import pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import cloudpickle
 import numpy as np
 import pytest


### PR DESCRIPTION
Because of [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy) NumPy only supports ≥3.10 now.

Also, Zarr, NetworkX, and ([soon](https://github.com/pydata/xarray/pull/8937)) Xarray will support only ≥3.10.