### PR TITLE
Create a copy of a `PipeFunc` in `Pipeline.add`

### DIFF
--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -717,13 +717,12 @@ class NestedPipeFunc(PipeFunc):
         from pipefunc import Pipeline
 
         _validate_pipefuncs(pipefuncs)
-        self.pipefuncs: list[PipeFunc] = [f.copy() for f in pipefuncs]
-        self.pipeline = Pipeline(self.pipefuncs, copy_funcs=False)  # type: ignore[arg-type]
+        self.pipeline = Pipeline(pipefuncs)  # type: ignore[arg-type]
         _validate_single_leaf_node(self.pipeline.leaf_nodes)
         _validate_output_name(output_name, self._all_outputs)
         self._output_name: _OUTPUT_TYPE = output_name or self._all_outputs
         self.debug = False  # The underlying PipeFuncs will handle this
-        self.cache = any(f.cache for f in self.pipefuncs)
+        self.cache = any(f.cache for f in self.pipeline.functions)
         self.save_function = None
         self._output_picker = None
         self._profile = False
@@ -732,10 +731,10 @@ class NestedPipeFunc(PipeFunc):
             k: v for k, v in self.pipeline.defaults.items() if k in self.parameters
         }
         self._bound: dict[str, Any] = {}
-        self.resources = _maybe_max_resources(resources, self.pipefuncs)
+        self.resources = _maybe_max_resources(resources, self.pipeline.functions)
         self.profiling_stats = None
         self.mapspec = self._combine_mapspecs() if mapspec is None else _maybe_mapspec(mapspec)
-        for f in self.pipefuncs:
+        for f in self.pipeline.functions:
             f.mapspec = None  # MapSpec is handled by the NestedPipeFunc
         self._validate_mapspec()
         self._validate_names()
@@ -744,14 +743,14 @@ class NestedPipeFunc(PipeFunc):
         # Pass the mapspec to the new instance because we set
         # the child mapspecs to None in the __init__
         return NestedPipeFunc(
-            self.pipefuncs,
+            self.pipeline.functions,
             output_name=self._output_name,
             renames=self._renames,
             mapspec=self.mapspec,
         )
 
     def _combine_mapspecs(self) -> MapSpec | None:
-        mapspecs = [f.mapspec for f in self.pipefuncs]
+        mapspecs = [f.mapspec for f in self.pipeline.functions]
         if all(m is None for m in mapspecs):
             return None
         _validate_combinable_mapspecs(mapspecs)
@@ -769,14 +768,14 @@ class NestedPipeFunc(PipeFunc):
     @functools.cached_property
     def _all_outputs(self) -> tuple[str, ...]:
         outputs: set[str] = set()
-        for f in self.pipefuncs:
+        for f in self.pipeline.functions:
             outputs.update(at_least_tuple(f.output_name))
         return tuple(sorted(outputs))
 
     @functools.cached_property
     def _all_inputs(self) -> tuple[str, ...]:
         inputs: set[str] = set()
-        for f in self.pipefuncs:
+        for f in self.pipeline.functions:
             inputs.update(f.parameters)
         return tuple(sorted(inputs))
 
@@ -786,7 +785,7 @@ class NestedPipeFunc(PipeFunc):
         return _NestedFuncWrapper(func.call_full_output, self.output_name)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(pipefuncs={self.pipefuncs})"
+        return f"{self.__class__.__name__}(pipefuncs={self.pipeline.functions})"
 
 
 def _maybe_max_resources(

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -718,7 +718,7 @@ class NestedPipeFunc(PipeFunc):
 
         _validate_pipefuncs(pipefuncs)
         self.pipefuncs: list[PipeFunc] = [f.copy() for f in pipefuncs]
-        self.pipeline = Pipeline(self.pipefuncs)  # type: ignore[arg-type]
+        self.pipeline = Pipeline(self.pipefuncs, copy_funcs=False)  # type: ignore[arg-type]
         _validate_single_leaf_node(self.pipeline.leaf_nodes)
         _validate_output_name(output_name, self._all_outputs)
         self._output_name: _OUTPUT_TYPE = output_name or self._all_outputs

--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -197,9 +197,6 @@ class Pipeline:
         else:
             f: PipeFunc = f.copy()  # type: ignore[no-redef]
 
-        if not isinstance(f, PipeFunc):
-            msg = f"`f` must be a `PipeFunc` or callable, got {type(f)}"
-            raise TypeError(msg)
         self.functions.append(f)
 
         if self.profile is not None:

--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -167,7 +167,10 @@ class Pipeline:
                 f.debug = value
 
     def add(
-        self, f: PipeFunc | Callable, mapspec: str | MapSpec | None = None, copy: bool = True
+        self,
+        f: PipeFunc | Callable,
+        mapspec: str | MapSpec | None = None,
+        copy: bool = True,
     ) -> PipeFunc:
         """Add a function to the pipeline.
 
@@ -264,6 +267,14 @@ class Pipeline:
                 for name in f.output_name:
                     output_to_func[name] = f
         return output_to_func
+
+    def __getitem__(self, output_name: _OUTPUT_TYPE) -> PipeFunc:
+        """Return the function corresponding to a specific output name."""
+        return self.output_to_func[output_name]
+
+    def __contains__(self, output_name: _OUTPUT_TYPE) -> bool:
+        """Check if the pipeline contains a function with a specific output name."""
+        return output_name in self.output_to_func
 
     @functools.cached_property
     def node_mapping(self) -> dict[_OUTPUT_TYPE, PipeFunc | str]:

--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -191,18 +191,12 @@ class Pipeline:
                 mapspec = MapSpec.from_string(mapspec)
             f.mapspec = mapspec
             f._validate_mapspec()
+        elif not isinstance(f, PipeFunc):
+            msg = f"`f` must be a `PipeFunc` or callable, got {type(f)}"
+            raise TypeError(msg)
         else:
-            if not isinstance(f, PipeFunc):
-                msg = f"`f` must be a `PipeFunc` or callable, got {type(f)}"
-                raise TypeError(msg)
             f: PipeFunc = f.copy()  # type: ignore[no-redef]
 
-        if not isinstance(f, PipeFunc):
-            msg = f"`f` must be a `PipeFunc` or callable, got {type(f)}"
-            raise TypeError(msg)
-        if not isinstance(f, PipeFunc):
-            msg = f"`f` must be a `PipeFunc` or callable, got {type(f)}"
-            raise TypeError(msg)
         if not isinstance(f, PipeFunc):
             msg = f"`f` must be a `PipeFunc` or callable, got {type(f)}"
             raise TypeError(msg)

--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -269,6 +269,19 @@ class Pipeline:
 
     @functools.cached_property
     def output_to_func(self) -> dict[_OUTPUT_TYPE, PipeFunc]:
+        """Return a mapping from output names to functions.
+
+        The mapping includes functions with multiple outputs both as individual
+        outputs and as tuples of outputs. For example, if a function has the
+        output name ``("a", "b")``, the mapping will include both ``"a"``,
+        ``"b"``, and ``("a", "b")`` as keys.
+
+        See Also
+        --------
+        __getitem__
+            Shortcut for accessing the function corresponding to a specific output name.
+
+        """
         output_to_func: dict[_OUTPUT_TYPE, PipeFunc] = {}
         for f in self.functions:
             output_to_func[f.output_name] = f
@@ -278,7 +291,14 @@ class Pipeline:
         return output_to_func
 
     def __getitem__(self, output_name: _OUTPUT_TYPE) -> PipeFunc:
-        """Return the function corresponding to a specific output name."""
+        """Return the function corresponding to a specific output name.
+
+        See Also
+        --------
+        output_to_func
+            The mapping from output names to functions.
+
+        """
         return self.output_to_func[output_name]
 
     def __contains__(self, output_name: _OUTPUT_TYPE) -> bool:

--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -191,6 +191,18 @@ class Pipeline:
                 mapspec = MapSpec.from_string(mapspec)
             f.mapspec = mapspec
             f._validate_mapspec()
+        else:
+            if not isinstance(f, PipeFunc):
+                msg = f"`f` must be a `PipeFunc` or callable, got {type(f)}"
+                raise TypeError(msg)
+            f: PipeFunc = f.copy()  # type: ignore[no-redef]
+
+        if not isinstance(f, PipeFunc):
+            msg = f"`f` must be a `PipeFunc` or callable, got {type(f)}"
+            raise TypeError(msg)
+        if not isinstance(f, PipeFunc):
+            msg = f"`f` must be a `PipeFunc` or callable, got {type(f)}"
+            raise TypeError(msg)
         if not isinstance(f, PipeFunc):
             msg = f"`f` must be a `PipeFunc` or callable, got {type(f)}"
             raise TypeError(msg)

--- a/pipefunc/sweep.py
+++ b/pipefunc/sweep.py
@@ -514,12 +514,12 @@ def set_cache_for_sweep(
 ) -> None:
     """Set the cache for a sweep of a pipeline."""
     # Disable for the output node
-    pipeline.output_to_func[output_name].cache = False  # type: ignore[union-attr]
+    pipeline[output_name].cache = False  # type: ignore[union-attr]
     cnt = count_sweep(output_name, sweep, pipeline)
     max_executions = {k: max(v.values()) for k, v in cnt.items()}
     for _output_name, n in max_executions.items():
         enable_cache = n >= min_executions
-        func = pipeline.output_to_func[_output_name]
+        func = pipeline[_output_name]
         if verbose:
             print(f"Setting cache for '{_output_name}' to {enable_cache} (n={n})")
         func.cache = enable_cache  # type: ignore[union-attr]

--- a/tests/map/test_pipeline_mapspec.py
+++ b/tests/map/test_pipeline_mapspec.py
@@ -18,14 +18,14 @@ def test_adding_zipped_axes_to_mapspec_less_pipeline() -> None:
     def f_e(c, d, x=1):
         return c * d * x
 
-    pipeline = Pipeline([f_c, f_d, f_e], copy_funcs=False)
+    pipeline = Pipeline([f_c, f_d, f_e])
     pipeline.add_mapspec_axis("a", axis="i")
     pipeline.add_mapspec_axis("b", axis="i")
     pipeline.add_mapspec_axis("x", axis="j")
 
-    assert str(f_c.mapspec) == "a[i], b[i] -> c[i]"
-    assert str(f_d.mapspec) == "c[i], b[i], x[j] -> d[i, j]"
-    assert str(f_e.mapspec) == "d[i, j], c[i], x[j] -> e[i, j]"
+    assert str(pipeline["c"].mapspec) == "a[i], b[i] -> c[i]"
+    assert str(pipeline["d"].mapspec) == "c[i], b[i], x[j] -> d[i, j]"
+    assert str(pipeline["e"].mapspec) == "d[i, j], c[i], x[j] -> e[i, j]"
 
     assert pipeline.mapspecs_as_strings == [
         "a[i], b[i] -> c[i]",
@@ -59,14 +59,14 @@ def test_adding_axes_to_mapspec_less_pipeline() -> None:
     def f_e(c, d, x=1):
         return c * d * x
 
-    pipeline = Pipeline([f_c, f_d, f_e], copy_funcs=False)
+    pipeline = Pipeline([f_c, f_d, f_e])
     pipeline.add_mapspec_axis("a", axis="i")
     pipeline.add_mapspec_axis("b", axis="j")
     pipeline.add_mapspec_axis("x", axis="k")
 
-    assert str(f_c.mapspec) == "a[i], b[j] -> c[i, j]"
-    assert str(f_d.mapspec) == "c[i, j], b[j], x[k] -> d[i, j, k]"
-    assert str(f_e.mapspec) == "d[i, j, k], c[i, j], x[k] -> e[i, j, k]"
+    assert str(pipeline["c"].mapspec) == "a[i], b[j] -> c[i, j]"
+    assert str(pipeline["d"].mapspec) == "c[i, j], b[j], x[k] -> d[i, j, k]"
+    assert str(pipeline["e"].mapspec) == "d[i, j, k], c[i, j], x[k] -> e[i, j, k]"
 
     assert pipeline.mapspecs_as_strings == [
         "a[i], b[j] -> c[i, j]",
@@ -80,12 +80,12 @@ def test_add_mapspec_axis_multiple_axes() -> None:
     def func(a, b):
         return a + b
 
-    pipeline = Pipeline([func], copy_funcs=False)
+    pipeline = Pipeline([func])
 
     pipeline.add_mapspec_axis("a", axis="k")
     pipeline.add_mapspec_axis("b", axis="l")
 
-    assert str(func.mapspec) == "a[i, k], b[j, l] -> result[i, j, k, l]"
+    assert str(pipeline["result"].mapspec) == "a[i, k], b[j, l] -> result[i, j, k, l]"
 
 
 def test_add_mapspec_axis_parameter_in_output() -> None:
@@ -93,11 +93,11 @@ def test_add_mapspec_axis_parameter_in_output() -> None:
     def func(a):
         return a
 
-    pipeline = Pipeline([func], copy_funcs=False)
+    pipeline = Pipeline([func])
 
     pipeline.add_mapspec_axis("a", axis="k")
 
-    assert str(func.mapspec) == "a[i, j, k] -> result[i, j, k]"
+    assert str(pipeline["result"].mapspec) == "a[i, j, k] -> result[i, j, k]"
 
 
 def test_consistent_indices() -> None:
@@ -185,13 +185,13 @@ def test_add_mapspec_axis_complex_pipeline() -> None:
     def func3(out2, out3):
         return out2 + out3
 
-    pipeline = Pipeline([func1, func2, func3], copy_funcs=False)
+    pipeline = Pipeline([func1, func2, func3])
 
     pipeline.add_mapspec_axis("a", axis="l")
 
-    assert str(func1.mapspec) == "a[i, l], b[j] -> out1[i, j, l], out2[i, j, l]"
-    assert str(func2.mapspec) == "out1[i, j, l], c[k] -> out3[i, j, k, l]"
-    assert str(func3.mapspec) == "out3[:, :, :, l], out2[:, :, l] -> out4[l]"
+    assert str(pipeline["out1"].mapspec) == "a[i, l], b[j] -> out1[i, j, l], out2[i, j, l]"
+    assert str(pipeline["out3"].mapspec) == "out1[i, j, l], c[k] -> out3[i, j, k, l]"
+    assert str(pipeline["out4"].mapspec) == "out3[:, :, :, l], out2[:, :, l] -> out4[l]"
 
 
 def test_multiple_outputs_order() -> None:

--- a/tests/map/test_pipeline_mapspec.py
+++ b/tests/map/test_pipeline_mapspec.py
@@ -18,7 +18,7 @@ def test_adding_zipped_axes_to_mapspec_less_pipeline() -> None:
     def f_e(c, d, x=1):
         return c * d * x
 
-    pipeline = Pipeline([f_c, f_d, f_e])
+    pipeline = Pipeline([f_c, f_d, f_e], copy_funcs=False)
     pipeline.add_mapspec_axis("a", axis="i")
     pipeline.add_mapspec_axis("b", axis="i")
     pipeline.add_mapspec_axis("x", axis="j")
@@ -59,7 +59,7 @@ def test_adding_axes_to_mapspec_less_pipeline() -> None:
     def f_e(c, d, x=1):
         return c * d * x
 
-    pipeline = Pipeline([f_c, f_d, f_e])
+    pipeline = Pipeline([f_c, f_d, f_e], copy_funcs=False)
     pipeline.add_mapspec_axis("a", axis="i")
     pipeline.add_mapspec_axis("b", axis="j")
     pipeline.add_mapspec_axis("x", axis="k")
@@ -80,7 +80,7 @@ def test_add_mapspec_axis_multiple_axes() -> None:
     def func(a, b):
         return a + b
 
-    pipeline = Pipeline([func])
+    pipeline = Pipeline([func], copy_funcs=False)
 
     pipeline.add_mapspec_axis("a", axis="k")
     pipeline.add_mapspec_axis("b", axis="l")
@@ -93,7 +93,7 @@ def test_add_mapspec_axis_parameter_in_output() -> None:
     def func(a):
         return a
 
-    pipeline = Pipeline([func])
+    pipeline = Pipeline([func], copy_funcs=False)
 
     pipeline.add_mapspec_axis("a", axis="k")
 
@@ -185,7 +185,7 @@ def test_add_mapspec_axis_complex_pipeline() -> None:
     def func3(out2, out3):
         return out2 + out3
 
-    pipeline = Pipeline([func1, func2, func3])
+    pipeline = Pipeline([func1, func2, func3], copy_funcs=False)
 
     pipeline.add_mapspec_axis("a", axis="l")
 

--- a/tests/map/test_run.py
+++ b/tests/map/test_run.py
@@ -631,7 +631,7 @@ def test_add_mapspec_axis(tmp_path: Path) -> None:
     def three(two, d):
         return two / d
 
-    pipeline = Pipeline([one, two, three])
+    pipeline = Pipeline([one, two, three], copy_funcs=False)
     inputs = {"a": np.ones((2,)), "b": [1, 1], "d": 1}
     expected = {"b": (2,), "a": (2,), "one": (2, 2)}
     shapes, masks = map_shapes(pipeline, inputs)
@@ -689,7 +689,7 @@ def test_mapspec_internal_shapes(tmp_path: Path) -> None:
     def take_sum(y: list[int]) -> int:
         return sum(y)
 
-    pipeline = Pipeline([generate_ints, add, take_sum])
+    pipeline = Pipeline([generate_ints, add, take_sum], copy_funcs=False)
 
     pipeline.add_mapspec_axis("z", axis="k")
     assert str(generate_ints.mapspec) == "... -> x[i]"
@@ -821,6 +821,7 @@ def test_add_mapspec_axis_from_step(storage: str, tmp_path: Path) -> None:
             side_chain,
             take_sum,
         ],
+        copy_funcs=False,
     )
 
     inputs = {"n": 4, "z": 1}

--- a/tests/map/test_run.py
+++ b/tests/map/test_run.py
@@ -631,7 +631,7 @@ def test_add_mapspec_axis(tmp_path: Path) -> None:
     def three(two, d):
         return two / d
 
-    pipeline = Pipeline([one, two, three], copy_funcs=False)
+    pipeline = Pipeline([one, two, three])
     inputs = {"a": np.ones((2,)), "b": [1, 1], "d": 1}
     expected = {"b": (2,), "a": (2,), "one": (2, 2)}
     shapes, masks = map_shapes(pipeline, inputs)
@@ -642,9 +642,9 @@ def test_add_mapspec_axis(tmp_path: Path) -> None:
 
     # Adding another axis to "one"
     pipeline.add_mapspec_axis("a", axis="k")
-    assert str(one.mapspec) == "a[i, k], b[j] -> one[i, j, k]"
-    assert str(two.mapspec) == "one[:, :, k] -> two[k]"
-    assert str(three.mapspec) == "two[k] -> three[k]"
+    assert str(pipeline["one"].mapspec) == "a[i, k], b[j] -> one[i, j, k]"
+    assert str(pipeline["two"].mapspec) == "one[:, :, k] -> two[k]"
+    assert str(pipeline["three"].mapspec) == "two[k] -> three[k]"
 
     # Run the pipeline
     inputs = {"a": np.ones((2, 3)), "b": [1, 1], "d": 1}
@@ -657,9 +657,9 @@ def test_add_mapspec_axis(tmp_path: Path) -> None:
 
     # Adding another axis to "d"
     pipeline.add_mapspec_axis("d", axis="l")
-    assert str(one.mapspec) == "a[i, k], b[j] -> one[i, j, k]"
-    assert str(two.mapspec) == "one[:, :, k], d[l] -> two[k, l]"
-    assert str(three.mapspec) == "two[k, l], d[l] -> three[k, l]"
+    assert str(pipeline["one"].mapspec) == "a[i, k], b[j] -> one[i, j, k]"
+    assert str(pipeline["two"].mapspec) == "one[:, :, k], d[l] -> two[k, l]"
+    assert str(pipeline["three"].mapspec) == "two[k, l], d[l] -> three[k, l]"
 
     # Run the pipeline
     inputs = {"a": np.ones((2, 3)), "b": [1, 1], "d": [1, 1]}
@@ -689,12 +689,12 @@ def test_mapspec_internal_shapes(tmp_path: Path) -> None:
     def take_sum(y: list[int]) -> int:
         return sum(y)
 
-    pipeline = Pipeline([generate_ints, add, take_sum], copy_funcs=False)
+    pipeline = Pipeline([generate_ints, add, take_sum])
 
     pipeline.add_mapspec_axis("z", axis="k")
-    assert str(generate_ints.mapspec) == "... -> x[i]"
-    assert str(add.mapspec) == "x[i], z[k] -> y[i, k]"
-    assert str(take_sum.mapspec) == "y[:, k] -> sum[k]"
+    assert str(pipeline["x"].mapspec) == "... -> x[i]"
+    assert str(pipeline["y"].mapspec) == "x[i], z[k] -> y[i, k]"
+    assert str(pipeline["sum"].mapspec) == "y[:, k] -> sum[k]"
 
     inputs = {"n": 4, "z": [1, 2]}
     internal_shapes = {"x": 4}
@@ -821,7 +821,6 @@ def test_add_mapspec_axis_from_step(storage: str, tmp_path: Path) -> None:
             side_chain,
             take_sum,
         ],
-        copy_funcs=False,
     )
 
     inputs = {"n": 4, "z": 1}
@@ -842,10 +841,10 @@ def test_add_mapspec_axis_from_step(storage: str, tmp_path: Path) -> None:
     # Add an axis `j` to `x`
     pipeline_map = Pipeline(
         [
-            (generate_ints, "n[j] -> x[i, j]"),
-            (double_it, "x[i, j] -> y[i, j]"),
-            side_chain,
-            (take_sum, "y[:, j] -> sum[j]"),
+            (pipeline["x"], "n[j] -> x[i, j]"),
+            (pipeline["y"], "x[i, j] -> y[i, j]"),
+            pipeline["side"],
+            (pipeline["sum"], "y[:, j] -> sum[j]"),
         ],
     )
     inputs_map = {"n": [4], "z": 1}

--- a/tests/test_pipefunc.py
+++ b/tests/test_pipefunc.py
@@ -399,6 +399,7 @@ def test_tuple_outputs(tmp_path: Path):
         cache_type="lru",
         lazy=True,
         cache_kwargs={"shared": False},
+        copy_funcs=False,
     )
     f = pipeline.func("i")
     r = f.call_full_output(a=1, b=2, x=3)["i"].evaluate()
@@ -566,16 +567,16 @@ def test_drop_from_pipeline():
     def f3(c, d, x=1):
         return c * d * x
 
-    pipeline = Pipeline([f1, f2, f3])
+    pipeline = Pipeline([f1, f2, f3], copy_funcs=False)
     assert "d" in pipeline.output_to_func
     pipeline.drop(output_name="d")
     assert "d" not in pipeline.output_to_func
 
-    pipeline = Pipeline([f1, f2, f3])
+    pipeline = Pipeline([f1, f2, f3], copy_funcs=False)
     assert "d" in pipeline.output_to_func
     pipeline.drop(f=f2)
 
-    pipeline = Pipeline([f1, f2, f3])
+    pipeline = Pipeline([f1, f2, f3], copy_funcs=False)
 
     @pipefunc(output_name="e")
     def f4(c, d, x=1):
@@ -907,7 +908,7 @@ def test_renaming_output_name() -> None:
     def f(a, b):
         return a + b, 1
 
-    pipeline = Pipeline([f])
+    pipeline = Pipeline([f], copy_funcs=False)
     f.update_renames({"c": "c1"}, update_from="current")
     assert f.output_name == ("c1", "d")
     pipeline.update_renames({"c1": "c2"}, update_from="current")
@@ -979,7 +980,7 @@ def test_update_defaults_and_renames_with_pipeline() -> None:
     def g(c=999, d=666):
         return c * d
 
-    pipeline = Pipeline([f, g])
+    pipeline = Pipeline([f, g], copy_funcs=False)
 
     # Test initial pipeline parameters and defaults
     assert f.parameters == ("a1", "b")
@@ -1384,7 +1385,7 @@ def test_set_debug_and_profile():
     def f(a, b):
         return a + b
 
-    pipeline = Pipeline([f])
+    pipeline = Pipeline([f], copy_funcs=False)
     assert not f.debug
     assert not f.profile
     pipeline.debug = True

--- a/tests/test_pipefunc.py
+++ b/tests/test_pipefunc.py
@@ -567,12 +567,12 @@ def test_drop_from_pipeline():
         return c * d * x
 
     pipeline = Pipeline([f1, f2, f3])
-    assert "d" in pipeline.output_to_func
+    assert "d" in pipeline
     pipeline.drop(output_name="d")
-    assert "d" not in pipeline.output_to_func
+    assert "d" not in pipeline
 
     pipeline = Pipeline([f1, f2, f3])
-    assert "d" in pipeline.output_to_func
+    assert "d" in pipeline
     pipeline.drop(f=pipeline["d"])
 
     pipeline = Pipeline([f1, f2, f3])
@@ -1465,3 +1465,16 @@ def test_nesting_funcs_with_bound():
     pipeline.nest_funcs(["c", "d"], "d")
     assert pipeline("d", a="a", b="b") == "abb2"
     assert len(pipeline.functions) == 1
+
+
+def test_accessing_copied_pipefunc():
+    @pipefunc(output_name="c")
+    def f(a, b):
+        return a + b
+
+    pipeline = Pipeline([f])
+    with pytest.raises(
+        ValueError,
+        match=re.escape("you can access that function via `pipeline['c']`"),
+    ):
+        pipeline.drop(f=f)

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -25,7 +25,7 @@ def test_identify_combinable_nodes():
     def f_i(gg, b, e):  # noqa: ARG001
         pass
 
-    pipeline = Pipeline([f_d, f_e, f_i, f_gg])
+    pipeline = Pipeline([f_d, f_e, f_i, f_gg], copy_funcs=False)
 
     # `conservatively_combine=False`
     combinable_nodes = _identify_combinable_nodes(
@@ -72,7 +72,7 @@ def test_conservatively_combine():
     def f3(b, x, y):
         return x * y * b
 
-    pipeline = Pipeline([f1, f2, f3])
+    pipeline = Pipeline([f1, f2, f3], copy_funcs=False)
 
     root_args = pipeline.all_root_args
     assert root_args == {"x": ("a",), "y": ("a", "b"), "z": ("a", "b")}

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -29,7 +29,7 @@ def test_identify_combinable_nodes():
 
     # `conservatively_combine=False`
     combinable_nodes = _identify_combinable_nodes(
-        pipeline.output_to_func["i"],
+        pipeline["i"],
         pipeline.graph,
         pipeline.all_root_args,
         conservatively_combine=False,
@@ -44,7 +44,7 @@ def test_identify_combinable_nodes():
 
     # `conservatively_combine=True`
     combinable_nodes = _identify_combinable_nodes(
-        pipeline.output_to_func["i"],
+        pipeline["i"],
         pipeline.graph,
         pipeline.all_root_args,
         conservatively_combine=True,
@@ -79,7 +79,7 @@ def test_conservatively_combine():
 
     # Test with conservatively_combine=True
     combinable_nodes_true = _identify_combinable_nodes(
-        pipeline.output_to_func["z"],
+        pipeline["z"],
         pipeline.graph,
         pipeline.all_root_args,
         conservatively_combine=True,
@@ -95,7 +95,7 @@ def test_conservatively_combine():
 
     # Test with conservatively_combine=False
     combinable_nodes_false = _identify_combinable_nodes(
-        pipeline.output_to_func["z"],
+        pipeline["z"],
         pipeline.graph,
         pipeline.all_root_args,
         conservatively_combine=False,
@@ -150,11 +150,11 @@ def test_identify_combinable_nodes2():
         return a + f2 + f6
 
     pipeline = Pipeline([f1, f2, f3, f4, f5, f6, f7])
-    m = pipeline.output_to_func
+    m = pipeline
 
     expected = {m["f6"]: {m["f1"], m["f3"], m["f4"], m["f5"]}}
     combinable_nodes = _identify_combinable_nodes(
-        pipeline.output_to_func["f7"],
+        pipeline["f7"],
         pipeline.graph,
         pipeline.all_root_args,
     )

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -14,7 +14,7 @@ def test_identify_combinable_nodes():
         pass
 
     @pipefunc(output_name=("g", "h"))
-    def f_e(a, x=1):  # noqa: ARG001
+    def f_g(a, x=1):  # noqa: ARG001
         pass
 
     @pipefunc(output_name="gg")
@@ -25,7 +25,7 @@ def test_identify_combinable_nodes():
     def f_i(gg, b, e):  # noqa: ARG001
         pass
 
-    pipeline = Pipeline([f_d, f_e, f_i, f_gg], copy_funcs=False)
+    pipeline = Pipeline([f_d, f_g, f_i, f_gg])
 
     # `conservatively_combine=False`
     combinable_nodes = _identify_combinable_nodes(
@@ -34,10 +34,10 @@ def test_identify_combinable_nodes():
         pipeline.all_root_args,
         conservatively_combine=False,
     )
-    assert combinable_nodes == {f_gg: {f_e}, f_i: {f_d}}
+    assert combinable_nodes == {pipeline["gg"]: {pipeline["g"]}, pipeline["i"]: {pipeline["d"]}}
     simple = pipeline.simplified_pipeline(conservatively_combine=False)
     assert len(simple.functions) == 2
-    assert repr(simple.functions[0]) == "NestedPipeFunc(pipefuncs=[PipeFunc(f_gg), PipeFunc(f_e)])"
+    assert repr(simple.functions[0]) == "NestedPipeFunc(pipefuncs=[PipeFunc(f_gg), PipeFunc(f_g)])"
     assert repr(simple.functions[1]) == "NestedPipeFunc(pipefuncs=[PipeFunc(f_i), PipeFunc(f_d)])"
     assert simple.functions[0].output_name == ("g", "gg")
     assert simple.functions[1].output_name == "i"
@@ -49,12 +49,12 @@ def test_identify_combinable_nodes():
         pipeline.all_root_args,
         conservatively_combine=True,
     )
-    assert combinable_nodes == {f_gg: {f_e}}
+    assert combinable_nodes == {pipeline["gg"]: {pipeline["g"]}}
     simple = pipeline.simplified_pipeline(conservatively_combine=True)
     assert len(simple.functions) == 3
     assert repr(simple.functions[0]) == "PipeFunc(f_d)"
     assert repr(simple.functions[1]) == "PipeFunc(f_i)"
-    assert repr(simple.functions[2]) == "NestedPipeFunc(pipefuncs=[PipeFunc(f_gg), PipeFunc(f_e)])"
+    assert repr(simple.functions[2]) == "NestedPipeFunc(pipefuncs=[PipeFunc(f_gg), PipeFunc(f_g)])"
     assert simple.functions[1].output_name == "i"
     assert simple.functions[2].output_name == ("g", "gg")
 
@@ -72,7 +72,7 @@ def test_conservatively_combine():
     def f3(b, x, y):
         return x * y * b
 
-    pipeline = Pipeline([f1, f2, f3], copy_funcs=False)
+    pipeline = Pipeline([f1, f2, f3])
 
     root_args = pipeline.all_root_args
     assert root_args == {"x": ("a",), "y": ("a", "b"), "z": ("a", "b")}
@@ -100,7 +100,7 @@ def test_conservatively_combine():
         pipeline.all_root_args,
         conservatively_combine=False,
     )
-    assert combinable_nodes_false == {f3: {f2}}
+    assert combinable_nodes_false == {pipeline["z"]: {pipeline["y"]}}
 
     # Test simplified_pipeline with conservatively_combine=False
     simplified_pipeline_false = pipeline.simplified_pipeline(

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -106,9 +106,9 @@ def test_set_cache_for_sweep(pipeline):
     ]
     output_name = "e"
     set_cache_for_sweep(output_name, pipeline, sweep, verbose=True)
-    assert pipeline.output_to_func["c"].cache is True
-    assert pipeline.output_to_func["d"].cache is True
-    assert pipeline.output_to_func["e"].cache is False
+    assert pipeline["c"].cache is True
+    assert pipeline["d"].cache is True
+    assert pipeline["e"].cache is False
 
 
 def test_sweep_with_exclude():


### PR DESCRIPTION
Makes sure that later modifications of a `PipeFunc` won't affect the initialized `Pipeline`.