### PR TITLE
Get rid of `PipeFunc._default_resources`

### DIFF
--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -28,7 +28,7 @@ from pipefunc._utils import (
     format_function_call,
 )
 from pipefunc.lazy import evaluate_lazy
-from pipefunc.map._mapspec import ArraySpec, MapSpec, mapspec_axes, maybe_mapspec
+from pipefunc.map._mapspec import ArraySpec, MapSpec, mapspec_axes
 from pipefunc.resources import Resources
 
 if TYPE_CHECKING:
@@ -146,7 +146,7 @@ class PipeFunc(Generic[T]):
         self._output_name: _OUTPUT_TYPE = output_name
         self.debug = debug
         self.cache = cache
-        self.mapspec = maybe_mapspec(mapspec)
+        self.mapspec = _maybe_mapspec(mapspec)
         self._output_picker: Callable[[Any, str], Any] | None = output_picker
         self.profile = profile
         self._renames: dict[str, str] = renames or {}
@@ -902,7 +902,7 @@ class NestedPipeFunc(PipeFunc):
         self._bound: dict[str, Any] = {}
         self.resources_variable = None  # not supported in NestedPipeFunc
         self.profiling_stats = None
-        self.mapspec = self._combine_mapspecs() if mapspec is None else maybe_mapspec(mapspec)
+        self.mapspec = self._combine_mapspecs() if mapspec is None else _maybe_mapspec(mapspec)
         for f in self.pipeline.functions:
             f.mapspec = None  # MapSpec is handled by the NestedPipeFunc
         self._validate_mapspec()
@@ -1103,3 +1103,8 @@ def _prepend_name_with_scope(name: str, scope: str | None) -> str:
             stacklevel=3,
         )
     return f"{scope}.{name}"
+
+
+def _maybe_mapspec(mapspec: str | MapSpec | None) -> MapSpec | None:
+    """Return either a MapSpec or None, depending on the input."""
+    return MapSpec.from_string(mapspec) if isinstance(mapspec, str) else mapspec

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -28,7 +28,7 @@ from pipefunc._utils import (
     format_function_call,
 )
 from pipefunc.lazy import evaluate_lazy
-from pipefunc.map._mapspec import ArraySpec, MapSpec, mapspec_axes
+from pipefunc.map._mapspec import ArraySpec, MapSpec, mapspec_axes, maybe_mapspec
 from pipefunc.resources import Resources
 
 if TYPE_CHECKING:
@@ -146,7 +146,7 @@ class PipeFunc(Generic[T]):
         self._output_name: _OUTPUT_TYPE = output_name
         self.debug = debug
         self.cache = cache
-        self.mapspec = _maybe_mapspec(mapspec)
+        self.mapspec = maybe_mapspec(mapspec)
         self._output_picker: Callable[[Any, str], Any] | None = output_picker
         self.profile = profile
         self._renames: dict[str, str] = renames or {}
@@ -902,7 +902,7 @@ class NestedPipeFunc(PipeFunc):
         self._bound: dict[str, Any] = {}
         self.resources_variable = None  # not supported in NestedPipeFunc
         self.profiling_stats = None
-        self.mapspec = self._combine_mapspecs() if mapspec is None else _maybe_mapspec(mapspec)
+        self.mapspec = self._combine_mapspecs() if mapspec is None else maybe_mapspec(mapspec)
         for f in self.pipeline.functions:
             f.mapspec = None  # MapSpec is handled by the NestedPipeFunc
         self._validate_mapspec()
@@ -1080,10 +1080,6 @@ def _default_output_picker(
 ) -> Any:
     """Default output picker function for tuples."""
     return output[output_name.index(name)]
-
-
-def _maybe_mapspec(mapspec: str | MapSpec | None) -> MapSpec | None:
-    return MapSpec.from_string(mapspec) if isinstance(mapspec, str) else mapspec
 
 
 def _rename_output_name(

--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -189,7 +189,7 @@ class Pipeline:
             resources = Resources.maybe_with_defaults(f.resources, self._default_resources)
             f: PipeFunc = f.copy(  # type: ignore[no-redef]
                 resources=resources,
-                mapspec=_maybe_mapspec(mapspec) if mapspec is not None else f.mapspec,
+                mapspec=f.mapspec if mapspec is None else _maybe_mapspec(mapspec),
             )
         elif callable(f):
             f = PipeFunc(

--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -99,7 +99,8 @@ class Pipeline:
     default_resources
         Default resources to use for the pipeline functions. If ``None``,
         the resources are not set. Either a dict or a `pipefunc.resources.Resources`
-        instance can be provided.
+        instance can be provided. If provided, the resources in the `PipeFunc`
+        instances are updated with the default resources.
 
     """
 

--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -38,6 +38,7 @@ from pipefunc.map._mapspec import (
     MapSpec,
     mapspec_axes,
     mapspec_dimensions,
+    maybe_mapspec,
     validate_consistent_axes,
 )
 from pipefunc.map._run import run
@@ -186,12 +187,10 @@ class Pipeline:
         """
         if isinstance(f, PipeFunc):
             resources = Resources.maybe_with_defaults(f.resources, self._default_resources)
-            f: PipeFunc = f.copy(resources=resources)  # type: ignore[no-redef]
-            if mapspec is not None:
-                if isinstance(mapspec, str):
-                    mapspec = MapSpec.from_string(mapspec)
-                f.mapspec = mapspec
-                f._validate_mapspec()
+            f: PipeFunc = f.copy(  # type: ignore[no-redef]
+                resources=resources,
+                mapspec=maybe_mapspec(mapspec) if mapspec is not None else f.mapspec,
+            )
         elif callable(f):
             f = PipeFunc(
                 f,

--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeAlias, Union
 import networkx as nx
 
 from pipefunc._cache import DiskCache, HybridCache, LRUCache, SimpleCache
-from pipefunc._pipefunc import NestedPipeFunc, PipeFunc
+from pipefunc._pipefunc import NestedPipeFunc, PipeFunc, _maybe_mapspec
 from pipefunc._profile import print_profiling_stats
 from pipefunc._simplify import _func_node_colors, _identify_combinable_nodes, simplified_pipeline
 from pipefunc._utils import (
@@ -38,7 +38,6 @@ from pipefunc.map._mapspec import (
     MapSpec,
     mapspec_axes,
     mapspec_dimensions,
-    maybe_mapspec,
     validate_consistent_axes,
 )
 from pipefunc.map._run import run
@@ -190,7 +189,7 @@ class Pipeline:
             resources = Resources.maybe_with_defaults(f.resources, self._default_resources)
             f: PipeFunc = f.copy(  # type: ignore[no-redef]
                 resources=resources,
-                mapspec=maybe_mapspec(mapspec) if mapspec is not None else f.mapspec,
+                mapspec=_maybe_mapspec(mapspec) if mapspec is not None else f.mapspec,
             )
         elif callable(f):
             f = PipeFunc(

--- a/pipefunc/map/_mapspec.py
+++ b/pipefunc/map/_mapspec.py
@@ -529,8 +529,3 @@ def trace_dependencies(mapspecs: list[MapSpec]) -> dict[str, dict[str, tuple[str
         output_name: {name: order_like_mapspec_axes(name, axs) for name, axs in dct.items()}
         for output_name, dct in reordered.items()
     }
-
-
-def maybe_mapspec(mapspec: str | MapSpec | None) -> MapSpec | None:
-    """Return either a MapSpec or None, depending on the input."""
-    return MapSpec.from_string(mapspec) if isinstance(mapspec, str) else mapspec

--- a/pipefunc/map/_mapspec.py
+++ b/pipefunc/map/_mapspec.py
@@ -529,3 +529,7 @@ def trace_dependencies(mapspecs: list[MapSpec]) -> dict[str, dict[str, tuple[str
         output_name: {name: order_like_mapspec_axes(name, axs) for name, axs in dct.items()}
         for output_name, dct in reordered.items()
     }
+
+
+def maybe_mapspec(mapspec: str | MapSpec | None) -> MapSpec | None:
+    return MapSpec.from_string(mapspec) if isinstance(mapspec, str) else mapspec

--- a/pipefunc/map/_mapspec.py
+++ b/pipefunc/map/_mapspec.py
@@ -532,4 +532,5 @@ def trace_dependencies(mapspecs: list[MapSpec]) -> dict[str, dict[str, tuple[str
 
 
 def maybe_mapspec(mapspec: str | MapSpec | None) -> MapSpec | None:
+    """Return either a MapSpec or None, depending on the input."""
     return MapSpec.from_string(mapspec) if isinstance(mapspec, str) else mapspec

--- a/tests/test_pipefunc.py
+++ b/tests/test_pipefunc.py
@@ -1819,10 +1819,6 @@ def test_resources_variable_in_nested_func_with_defaults() -> None:
     nf = NestedPipeFunc([f, g], output_name="d", resources={"num_gpus": 3})
     pipeline = Pipeline([nf], default_resources={"memory": "4GB", "num_gpus": 1})
 
-    # The pipeline adds the default resources to the nested function
-    assert nf._default_resources is None
-    assert pipeline["d"]._default_resources is not None
-
     assert isinstance(pipeline["d"].resources, Resources)
     assert pipeline["d"].resources == Resources(num_gpus=3, memory="4GB")
     r = pipeline(a=1, b=2)


### PR DESCRIPTION
At the moment there is no real need to keep track of the original `resources` and `default_resources`. Removing this feature will simplify the code.