### PR TITLE
Rename `Resources` attributes `cpus`, `gpus`, `nodes`, `cpus_per_node` `time`

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -475,12 +475,12 @@ from pipefunc import pipefunc, Pipeline
 
 @pipefunc(
     output_name="c",
-    resources={"memory": "1GB", "num_cpus": 2},
+    resources={"memory": "1GB", "cpus": 2},
     resources_variable="resources",
 )
 def f(a, b, resources):
     print(f"Inside the function `f`, resources.memory: {resources.memory}")
-    print(f"Inside the function `f`, resources.num_cpus: {resources.num_cpus}")
+    print(f"Inside the function `f`, resources.cpus: {resources.cpus}")
     return a + b
 
 result = f(a=1, b=1)
@@ -488,16 +488,16 @@ print(f"Result: {result}")
 ```
 
 In this example, the `resources` argument is passed to the function `f` via the `resources_variable` parameter.
-Inside the function, you can access the attributes of the `Resources` instance using `resources.memory` and `resources.num_cpus`.
+Inside the function, you can access the attributes of the `Resources` instance using `resources.memory` and `resources.cpus`.
 
 As you can see, the function `f` has access to the `resources` object and can inspect its attributes directly.
 
 Similarly, when using a `Pipeline`, you can inspect the `Resources` inside the functions:
 
 ```{code-cell} ipython3
-@pipefunc(output_name="d", resources={"num_gpus": 4}, resources_variable="resources")
+@pipefunc(output_name="d", resources={"gpus": 4}, resources_variable="resources")
 def g(c, resources):
-    print(f"Inside the function `g`, resources.num_gpus: {resources.num_gpus}")
+    print(f"Inside the function `g`, resources.gpus: {resources.gpus}")
     return c * 2
 
 pipeline = Pipeline([f, g])
@@ -507,7 +507,7 @@ print(f"Pipeline result: {result}")
 
 In this case, the `Pipeline` consists of two functions, `f` and `g`, both of which have access to their respective `resources` objects.
 
-The function `f` can inspect `resources.memory` and `resources.num_cpus`, while the function `g` can inspect `resources.num_gpus`.
+The function `f` can inspect `resources.memory` and `resources.cpus`, while the function `g` can inspect `resources.gpus`.
 
 By using the `resources_variable` argument, you can pass the `Resources` instance directly to the functions, allowing them to inspect the resource information as needed.
 
@@ -529,9 +529,9 @@ from pipefunc import pipefunc, Pipeline
 from pipefunc.resources import Resources
 
 def resources_func(kwargs):
-    num_gpus = kwargs["x"] + kwargs["y"]
-    print(f"Inside the resources function, num_gpus: {num_gpus}")
-    return Resources(num_gpus=num_gpus)
+    gpus = kwargs["x"] + kwargs["y"]
+    print(f"Inside the resources function, gpus: {gpus}")
+    return Resources(gpus=gpus)
 
 @pipefunc(output_name="out1", resources=resources_func)
 def f(x, y):
@@ -541,7 +541,7 @@ result = f(x=2, y=3)
 print(f"Result: {result}")
 ```
 
-In this case, `f.resources` is a callable that takes a dictionary of input arguments and returns a `Resources` instance with `num_gpus` set to the sum of `x` and `y`.
+In this case, `f.resources` is a callable that takes a dictionary of input arguments and returns a `Resources` instance with `gpus` set to the sum of `x` and `y`.
 
 The `f.resources` callable is invoked with the dictionary of input arguments to determine the resources for that specific execution.
 
@@ -561,8 +561,8 @@ Now, let's see an example that uses both a `resources` callable and the `resourc
 
 ```{code-cell} ipython3
 def resources_with_cpu(kwargs):
-    num_cpus = kwargs["out1"] + kwargs["z"]
-    return Resources(num_cpus=num_cpus)
+    cpus = kwargs["out1"] + kwargs["z"]
+    return Resources(cpus=cpus)
 
 @pipefunc(
     output_name="out2",
@@ -570,17 +570,17 @@ def resources_with_cpu(kwargs):
     resources_variable="resources",
 )
 def g(out1, z, resources):
-    print(f"Inside the function `g`, resources.num_cpus: {resources.num_cpus}")
+    print(f"Inside the function `g`, resources.cpus: {resources.cpus}")
     return out1 * z
 
 result = g(out1=2, z=3)
 print(f"Result: {result}")
 ```
 
-In this case, `g.resources` is a callable that takes a dictionary of input arguments and returns a `Resources` instance with `num_cpus` set to the sum of `out1` and `z`
+In this case, `g.resources` is a callable that takes a dictionary of input arguments and returns a `Resources` instance with `cpus` set to the sum of `out1` and `z`
 The resulting `Resources` instance is then passed to the function `g` via the `resources` parameter.
 
-The `resources` callable dynamically creates a `Resources` instance based on the input arguments, and the function `g` can access the `num_cpus` attribute of the `resources` object inside the function.
+The `resources` callable dynamically creates a `Resources` instance based on the input arguments, and the function `g` can access the `cpus` attribute of the `resources` object inside the function.
 
 Combining both functions into a pipeline
 

--- a/example.ipynb
+++ b/example.ipynb
@@ -1654,7 +1654,7 @@
     "\n",
     "\n",
     "# Pass in a `Resources` object that specifies the resources needed for each function\n",
-    "@pipefunc(output_name=\"double\", mapspec=\"x[i] -> double[i]\", resources=Resources(num_cpus=1))\n",
+    "@pipefunc(output_name=\"double\", mapspec=\"x[i] -> double[i]\", resources=Resources(cpus=1))\n",
     "def double_it(x: int) -> int:\n",
     "    return 2 * x\n",
     "\n",
@@ -1683,7 +1683,7 @@
     ")\n",
     "learners_dict.to_slurm_run(\n",
     "    returns=\"kwargs\",  # or \"run_manager\" to return a `adaptive_scheduler.RunManager` object\n",
-    "    default_resources={\"num_cpus\": 2, \"memory\": \"8GB\"},\n",
+    "    default_resources={\"cpus\": 2, \"memory\": \"8GB\"},\n",
     ")"
    ]
   },

--- a/pipefunc/map/adaptive_scheduler.py
+++ b/pipefunc/map/adaptive_scheduler.py
@@ -126,11 +126,11 @@ def _update_resources(  # noqa: PLR0912
     else:
         r = resources.with_defaults(tracker.default_resources)
     assert r is not None
-    if (v := tracker.get(r, "num_cpus")) is not None:
+    if (v := tracker.get(r, "cpus")) is not None:
         resources_dict["cores_per_node"].append(v)
-    if (v := tracker.get(r, "num_cpus_per_node")) is not None:
+    if (v := tracker.get(r, "cpus_per_node")) is not None:
         resources_dict["cores_per_node"].append(v)
-    if (v := tracker.get(r, "num_nodes")) is not None:
+    if (v := tracker.get(r, "nodes")) is not None:
         resources_dict["nodes"].append(v)
     if (v := tracker.get(r, "partition")) is not None:
         resources_dict["partition"].append(v)
@@ -139,10 +139,10 @@ def _update_resources(  # noqa: PLR0912
     _extra_scheduler = []
     if r.memory:
         _extra_scheduler.append(f"--mem={r.memory}")
-    if r.num_gpus:
-        _extra_scheduler.append(f"--gres=gpu:{r.num_gpus}")
-    if r.wall_time:
-        _extra_scheduler.append(f"--time={r.wall_time}")
+    if r.gpus:
+        _extra_scheduler.append(f"--gres=gpu:{r.gpus}")
+    if r.time:
+        _extra_scheduler.append(f"--time={r.time}")
     if r.extra_args:
         for key, value in r.extra_args.items():
             _extra_scheduler.append(f"--{key}={value}")

--- a/pipefunc/resources.py
+++ b/pipefunc/resources.py
@@ -15,18 +15,18 @@ class Resources:
 
     Parameters
     ----------
-    num_cpus
+    cpus
         The number of CPUs required for the job. Must be a positive integer.
-    num_gpus
+    gpus
         The number of GPUs required for the job. Must be a non-negative integer.
-    num_nodes
+    nodes
         The number of nodes required for the job. Must be a positive integer.
-    num_cpus_per_node
+    cpus_per_node
         The number of CPUs per node required for the job. Must be a positive integer.
     memory
         The memory required for the job. Must be a valid string (e.g., ``'2GB'``, ``'500MB'``).
-    wall_time
-        The wall time required for the job. Must be a valid string (e.g., ``'2:00:00'``, ``'48:00:00'``).
+    time
+        The time required for the job. Must be a valid string (e.g., ``'2:00:00'``, ``'48:00:00'``).
     partition
         The partition to submit the job to.
     extra_args
@@ -39,27 +39,27 @@ class Resources:
 
     Notes
     -----
-    - `num_cpus` and `num_nodes` cannot be specified together.
-    - `num_cpus_per_node` must be specified with `num_nodes`.
+    - `cpus` and `nodes` cannot be specified together.
+    - `cpus_per_node` must be specified with `nodes`.
 
     Examples
     --------
-    >>> resources = Resources(num_cpus=4, memory='16GB', wall_time='2:00:00')
-    >>> resources.num_cpus
+    >>> resources = Resources(cpus=4, memory='16GB', time='2:00:00')
+    >>> resources.cpus
     4
     >>> resources.memory
     '16GB'
-    >>> resources.wall_time
+    >>> resources.time
     '2:00:00'
 
     """
 
-    num_cpus: int | None = None
-    num_gpus: int | None = None
-    num_nodes: int | None = None
-    num_cpus_per_node: int | None = None
+    cpus: int | None = None
+    gpus: int | None = None
+    nodes: int | None = None
+    cpus_per_node: int | None = None
     memory: str | None = None
-    wall_time: str | None = None
+    time: str | None = None
     partition: str | None = None
     extra_args: dict[str, Any] = field(default_factory=dict)
 
@@ -72,32 +72,32 @@ class Resources:
             If any of the input parameters do not meet the specified constraints.
 
         """
-        if self.num_cpus is not None and self.num_cpus <= 0:
-            msg = "num_cpus must be a positive integer."
+        if self.cpus is not None and self.cpus <= 0:
+            msg = "cpus must be a positive integer."
             raise ValueError(msg)
-        if self.num_gpus is not None and self.num_gpus < 0:
-            msg = "num_gpus must be a non-negative integer."
+        if self.gpus is not None and self.gpus < 0:
+            msg = "gpus must be a non-negative integer."
             raise ValueError(msg)
-        if self.num_nodes is not None and self.num_nodes <= 0:
-            msg = "num_nodes must be a positive integer."
+        if self.nodes is not None and self.nodes <= 0:
+            msg = "nodes must be a positive integer."
             raise ValueError(msg)
-        if self.num_cpus_per_node is not None and self.num_cpus_per_node <= 0:
-            msg = "num_cpus_per_node must be a positive integer."
+        if self.cpus_per_node is not None and self.cpus_per_node <= 0:
+            msg = "cpus_per_node must be a positive integer."
             raise ValueError(msg)
         if self.memory is not None and not self._is_valid_memory(self.memory):
             msg = f"memory must be a valid string (e.g., '2GB', '500MB'), not '{self.memory}'."
             raise ValueError(msg)
-        if self.wall_time is not None and not self._is_valid_wall_time(self.wall_time):
-            msg = "wall_time must be a valid string (e.g., '2:00:00', '48:00:00')."
+        if self.time is not None and not self._is_valid_wall_time(self.time):
+            msg = "time must be a valid string (e.g., '2:00:00', '48:00:00')."
             raise ValueError(msg)
-        if self.num_nodes and self.num_cpus:
+        if self.nodes and self.cpus:
             msg = (
-                "num_nodes and num_cpus cannot be specified together."
-                " Either use num_nodes and num_cpus_per_node or use num_cpus alone."
+                "nodes and cpus cannot be specified together."
+                " Either use nodes and cpus_per_node or use cpus alone."
             )
             raise ValueError(msg)
-        if self.num_cpus_per_node and not self.num_nodes:
-            msg = "num_cpus_per_node must be specified with num_nodes."
+        if self.cpus_per_node and not self.nodes:
+            msg = "cpus_per_node must be specified with nodes."
             raise ValueError(msg)
 
     @staticmethod
@@ -156,9 +156,9 @@ class Resources:
         raise ValueError(msg)
 
     @staticmethod
-    def _is_valid_wall_time(wall_time: str) -> bool:
+    def _is_valid_wall_time(time: str) -> bool:
         pattern = re.compile(r"^(\d+:)?(\d{2}:)?\d{2}:\d{2}$")
-        return bool(pattern.match(wall_time))
+        return bool(pattern.match(time))
 
     def to_slurm_options(self) -> str:
         """Convert the Resources instance to SLURM options.
@@ -170,18 +170,18 @@ class Resources:
 
         """
         options = []
-        if self.num_cpus:
-            options.append(f"--cpus-per-task={self.num_cpus}")
-        if self.num_gpus:
-            options.append(f"--gres=gpu:{self.num_gpus}")
-        if self.num_nodes:
-            options.append(f"--nodes={self.num_nodes}")
-        if self.num_cpus_per_node:
-            options.append(f"--cpus-per-node={self.num_cpus_per_node}")
+        if self.cpus:
+            options.append(f"--cpus-per-task={self.cpus}")
+        if self.gpus:
+            options.append(f"--gres=gpu:{self.gpus}")
+        if self.nodes:
+            options.append(f"--nodes={self.nodes}")
+        if self.cpus_per_node:
+            options.append(f"--cpus-per-node={self.cpus_per_node}")
         if self.memory:
             options.append(f"--mem={self.memory}")
-        if self.wall_time:
-            options.append(f"--time={self.wall_time}")
+        if self.time:
+            options.append(f"--time={self.time}")
         if self.partition:
             options.append(f"--partition={self.partition}")
         for key, value in self.extra_args.items():
@@ -229,26 +229,26 @@ class Resources:
             return Resources()
 
         max_data: dict[str, Any] = {
-            "num_cpus": None,
-            "num_gpus": None,
+            "cpus": None,
+            "gpus": None,
             "memory": None,
-            "wall_time": None,
+            "time": None,
             "partition": None,
             "extra_args": {},
         }
 
         for resources in resources_list:
-            if resources.num_cpus is not None:
-                max_data["num_cpus"] = (
-                    resources.num_cpus
-                    if max_data["num_cpus"] is None
-                    else max(max_data["num_cpus"], resources.num_cpus)
+            if resources.cpus is not None:
+                max_data["cpus"] = (
+                    resources.cpus
+                    if max_data["cpus"] is None
+                    else max(max_data["cpus"], resources.cpus)
                 )
-            if resources.num_gpus is not None:
-                max_data["num_gpus"] = (
-                    resources.num_gpus
-                    if max_data["num_gpus"] is None
-                    else max(max_data["num_gpus"], resources.num_gpus)
+            if resources.gpus is not None:
+                max_data["gpus"] = (
+                    resources.gpus
+                    if max_data["gpus"] is None
+                    else max(max_data["gpus"], resources.gpus)
                 )
             if resources.memory is not None:
                 max_memory_gb = (
@@ -259,11 +259,11 @@ class Resources:
                 current_memory_gb = Resources._convert_to_gb(resources.memory)
                 if current_memory_gb > max_memory_gb:
                     max_data["memory"] = resources.memory
-            if resources.wall_time is not None:
-                max_data["wall_time"] = (
-                    resources.wall_time
-                    if max_data["wall_time"] is None
-                    else max(max_data["wall_time"], resources.wall_time)
+            if resources.time is not None:
+                max_data["time"] = (
+                    resources.time
+                    if max_data["time"] is None
+                    else max(max_data["time"], resources.time)
                 )
             if resources.partition is not None:
                 max_data["partition"] = resources.partition

--- a/tests/test_pipefunc.py
+++ b/tests/test_pipefunc.py
@@ -353,51 +353,51 @@ def test_nested_pipefunc_with_resources() -> None:
     # Test the resources are combined correctly
     nf = NestedPipeFunc(
         [
-            PipeFunc(f, "f", resources={"memory": "1GB", "num_cpus": 2}),
-            PipeFunc(g, "g", resources={"memory": "2GB", "num_cpus": 1}),
+            PipeFunc(f, "f", resources={"memory": "1GB", "cpus": 2}),
+            PipeFunc(g, "g", resources={"memory": "2GB", "cpus": 1}),
         ],
         output_name="g",
     )
     assert isinstance(nf.resources, Resources)
-    assert nf.resources.num_cpus == 2
+    assert nf.resources.cpus == 2
     assert nf.resources.memory == "2GB"
 
     # Test that the resources specified in NestedPipeFunc are used
     nf2 = NestedPipeFunc(
         [
-            PipeFunc(f, "f", resources={"memory": "1GB", "num_cpus": 2}),
-            PipeFunc(g, "g", resources={"memory": "2GB", "num_cpus": 1}),
+            PipeFunc(f, "f", resources={"memory": "1GB", "cpus": 2}),
+            PipeFunc(g, "g", resources={"memory": "2GB", "cpus": 1}),
         ],
         output_name="g",
-        resources={"memory": "3GB", "num_cpus": 3},
+        resources={"memory": "3GB", "cpus": 3},
     )
     assert isinstance(nf2.resources, Resources)
-    assert nf2.resources.num_cpus == 3
+    assert nf2.resources.cpus == 3
     assert nf2.resources.memory == "3GB"
 
     # Test that the resources specified in PipeFunc are used, with the other None
     nf3 = NestedPipeFunc(
         [
-            PipeFunc(f, "f", resources={"memory": "1GB", "num_cpus": 2}),
+            PipeFunc(f, "f", resources={"memory": "1GB", "cpus": 2}),
             PipeFunc(g, "g", resources=None),
         ],
         output_name="g",
     )
     assert isinstance(nf3.resources, Resources)
-    assert nf3.resources.num_cpus == 2
+    assert nf3.resources.cpus == 2
     assert nf3.resources.memory == "1GB"
 
     # Test that Resources instance in NestedPipeFunc is used
     nf3 = NestedPipeFunc(
         [
-            PipeFunc(f, "f", resources={"memory": "1GB", "num_cpus": 2}),
+            PipeFunc(f, "f", resources={"memory": "1GB", "cpus": 2}),
             PipeFunc(g, "g", resources=None),
         ],
         output_name="g",
-        resources=Resources(num_cpus=3, memory="3GB"),
+        resources=Resources(cpus=3, memory="3GB"),
     )
     assert isinstance(nf3.resources, Resources)
-    assert nf3.resources.num_cpus == 3
+    assert nf3.resources.cpus == 3
     assert nf3.resources.memory == "3GB"
 
 
@@ -449,13 +449,13 @@ def test_delayed_resources_in_nested_func() -> None:
     def g(c):
         return c
 
-    nf = NestedPipeFunc([f, g], resources={"num_gpus": 3})
+    nf = NestedPipeFunc([f, g], resources={"gpus": 3})
     assert isinstance(nf.resources, Resources)
-    assert nf.resources.num_gpus == 3
+    assert nf.resources.gpus == 3
     with pytest.raises(TypeError, match="`NestedPipeFunc` cannot have callable `resources`."):
         NestedPipeFunc(
             [f, g],
-            resources=lambda kwargs: Resources(num_gpus=kwargs["c"]),  # type: ignore[arg-type]
+            resources=lambda kwargs: Resources(gpus=kwargs["c"]),  # type: ignore[arg-type]
         )
 
 

--- a/tests/test_pipeline_resources.py
+++ b/tests/test_pipeline_resources.py
@@ -9,7 +9,7 @@ from pipefunc.resources import Resources
 
 
 def test_default_resources_from_pipeline() -> None:
-    @pipefunc(output_name="c", resources={"memory": "1GB", "num_cpus": 2})
+    @pipefunc(output_name="c", resources={"memory": "1GB", "cpus": 2})
     def f(a, b):
         return a + b
 
@@ -17,15 +17,15 @@ def test_default_resources_from_pipeline() -> None:
     def g(c):
         return c
 
-    pipeline1 = Pipeline([f, g], default_resources={"memory": "2GB", "num_cpus": 1})
+    pipeline1 = Pipeline([f, g], default_resources={"memory": "2GB", "cpus": 1})
 
     @pipefunc(output_name="e")
     def h(d):
         return d
 
-    pipeline2 = Pipeline([h], default_resources={"memory": "3GB", "num_cpus": 3})
+    pipeline2 = Pipeline([h], default_resources={"memory": "3GB", "cpus": 3})
 
-    @pipefunc(output_name="f", resources={"memory": "4GB", "num_cpus": 4})
+    @pipefunc(output_name="f", resources={"memory": "4GB", "cpus": 4})
     def i(e):
         return e
 
@@ -38,19 +38,19 @@ def test_default_resources_from_pipeline() -> None:
     assert isinstance(pipeline["e"].resources, Resources)
     assert isinstance(pipeline["f"].resources, Resources)
 
-    assert pipeline["c"].resources.num_cpus == 2
+    assert pipeline["c"].resources.cpus == 2
     assert pipeline["c"].resources.memory == "1GB"
-    assert pipeline["d"].resources.num_cpus == 1
+    assert pipeline["d"].resources.cpus == 1
     assert pipeline["d"].resources.memory == "2GB"
-    assert pipeline["e"].resources.num_cpus == 3
+    assert pipeline["e"].resources.cpus == 3
     assert pipeline["e"].resources.memory == "3GB"
-    assert pipeline["f"].resources.num_cpus == 4
+    assert pipeline["f"].resources.cpus == 4
 
 
 def test_resources_variable():
-    @pipefunc(output_name="c", resources_variable="resources", resources={"num_gpus": 8})
+    @pipefunc(output_name="c", resources_variable="resources", resources={"gpus": 8})
     def f_c(a, b, resources):  # noqa: ARG001
-        return resources.num_gpus
+        return resources.gpus
 
     assert f_c(a=1, b=2) == 8
 
@@ -58,23 +58,23 @@ def test_resources_variable():
     assert pipeline(a=1, b=2) == 8
 
     with pytest.raises(ValueError, match="Unexpected keyword arguments: `{'resources'}`"):
-        f_c(a=1, b=2, resources={"num_gpus": 4})
+        f_c(a=1, b=2, resources={"gpus": 4})
 
     with pytest.raises(ValueError, match="Unused keyword arguments: `resources`"):
-        pipeline(a=1, b=2, resources={"num_gpus": 4})
+        pipeline(a=1, b=2, resources={"gpus": 4})
 
 
 def test_resources_variable_nested_func():
-    @pipefunc(output_name="c", resources_variable="resources", resources={"num_gpus": 8})
+    @pipefunc(output_name="c", resources_variable="resources", resources={"gpus": 8})
     def f_c(a, b, resources):  # noqa: ARG001
-        return resources.num_gpus
+        return resources.gpus
 
     @pipefunc(output_name="d")
     def f_d(c):
         return c
 
     nf = NestedPipeFunc([f_c, f_d], output_name="d")
-    assert nf.resources.num_gpus == 8
+    assert nf.resources.gpus == 8
     assert nf(a=1, b=2) == 8
 
     pipeline = Pipeline([nf])
@@ -84,7 +84,7 @@ def test_resources_variable_nested_func():
 def test_resources_variable_with_callable_resources() -> None:
     @pipefunc(
         output_name="c",
-        resources=lambda kwargs: Resources(num_gpus=kwargs["a"] + kwargs["b"]),
+        resources=lambda kwargs: Resources(gpus=kwargs["a"] + kwargs["b"]),
         resources_variable="resources",
     )
     def f_c(a, b, resources):  # noqa: ARG001
@@ -109,7 +109,7 @@ def test_resources_variable_with_callable_resources() -> None:
     pipeline = Pipeline([f_c, f_d, f_e])
     r = pipeline(a=1, b=2)
     assert isinstance(r, Resources)
-    assert r.num_gpus == 3
+    assert r.gpus == 3
 
     with pytest.raises(
         ValueError,
@@ -132,21 +132,21 @@ def test_resources_variable_in_nested_func_with_defaults() -> None:
         assert isinstance(resources, Resources)
         return resources
 
-    nf = NestedPipeFunc([f, g], output_name="d", resources={"num_gpus": 3})
-    pipeline = Pipeline([nf], default_resources={"memory": "4GB", "num_gpus": 1})
+    nf = NestedPipeFunc([f, g], output_name="d", resources={"gpus": 3})
+    pipeline = Pipeline([nf], default_resources={"memory": "4GB", "gpus": 1})
 
     assert isinstance(pipeline["d"].resources, Resources)
-    assert pipeline["d"].resources == Resources(num_gpus=3, memory="4GB")
+    assert pipeline["d"].resources == Resources(gpus=3, memory="4GB")
     r = pipeline(a=1, b=2)
     assert isinstance(r, Resources)
-    assert r.num_gpus == 3
+    assert r.gpus == 3
     assert r.memory == "4GB"
 
 
 def test_resources_func_with_variable() -> None:
     def resources_with_cpu(kwargs) -> Resources:
-        num_cpus = kwargs["a"] + kwargs["b"]
-        return Resources(num_cpus=num_cpus)
+        cpus = kwargs["a"] + kwargs["b"]
+        return Resources(cpus=cpus)
 
     @pipefunc(
         output_name="i",
@@ -155,7 +155,7 @@ def test_resources_func_with_variable() -> None:
     )
     def j(a, b, resources):
         assert isinstance(resources, Resources)
-        assert resources.num_cpus == a + b
+        assert resources.cpus == a + b
         return a * b
 
     result = j(a=2, b=3)
@@ -170,8 +170,8 @@ def test_resources_func_with_variable() -> None:
 
 def test_with_resource_func_with_defaults():
     def resources_with_cpu(kwargs) -> Resources:
-        num_cpus = kwargs["a"] + kwargs["b"]
-        return Resources(num_cpus=num_cpus)
+        cpus = kwargs["a"] + kwargs["b"]
+        return Resources(cpus=cpus)
 
     @pipefunc(
         output_name="i",
@@ -180,13 +180,13 @@ def test_with_resource_func_with_defaults():
     )
     def j(a, b, resources):
         assert isinstance(resources, Resources)
-        assert resources.num_cpus == a + b
+        assert resources.cpus == a + b
         return resources
 
-    pipeline = Pipeline([j], default_resources={"num_gpus": 5, "num_cpus": 1000})
+    pipeline = Pipeline([j], default_resources={"gpus": 5, "cpus": 1000})
     result = pipeline(a=2, b=3)
-    assert result.num_cpus == 5
-    assert result.num_gpus == 5
+    assert result.cpus == 5
+    assert result.gpus == 5
     result = pipeline.map(inputs={"a": 2, "b": 3}, parallel=False, storage="dict")
-    assert result["i"].output.num_cpus == 5
-    assert result["i"].output.num_gpus == 5
+    assert result["i"].output.cpus == 5
+    assert result["i"].output.gpus == 5

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -90,9 +90,9 @@ def test_plot_nested_func():
 
 
 def test_plotting_resources():
-    @pipefunc(output_name="c", resources_variable="resources", resources={"num_gpus": 8})
+    @pipefunc(output_name="c", resources_variable="resources", resources={"gpus": 8})
     def f_c(a, b, resources):  # noqa: ARG001
-        return resources.num_gpus
+        return resources.gpus
 
     pipeline = Pipeline([f_c])
     pipeline.visualize()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -5,27 +5,27 @@ from pipefunc.resources import Resources
 
 def test_valid_resources_initialization():
     res = Resources(
-        num_cpus=4,
-        num_gpus=1,
+        cpus=4,
+        gpus=1,
         memory="16GB",
-        wall_time="2:00:00",
+        time="2:00:00",
         partition="gpu",
     )
-    assert res.num_cpus == 4
-    assert res.num_gpus == 1
+    assert res.cpus == 4
+    assert res.gpus == 1
     assert res.memory == "16GB"
-    assert res.wall_time == "2:00:00"
+    assert res.time == "2:00:00"
     assert res.partition == "gpu"
 
 
 def test_invalid_num_cpus():
-    with pytest.raises(ValueError, match="num_cpus must be a positive integer."):
-        Resources(num_cpus=-1)
+    with pytest.raises(ValueError, match="cpus must be a positive integer."):
+        Resources(cpus=-1)
 
 
 def test_invalid_num_gpus():
-    with pytest.raises(ValueError, match="num_gpus must be a non-negative integer."):
-        Resources(num_gpus=-1)
+    with pytest.raises(ValueError, match="gpus must be a non-negative integer."):
+        Resources(gpus=-1)
 
 
 def test_invalid_memory_format():
@@ -45,32 +45,32 @@ def test_invalid_memory_format():
 def test_invalid_wall_time_format():
     with pytest.raises(
         ValueError,
-        match=r"wall_time must be a valid string \(e\.g\., '2:00:00', '48:00:00'\).",
+        match=r"time must be a valid string \(e\.g\., '2:00:00', '48:00:00'\).",
     ):
-        Resources(wall_time="invalid")
+        Resources(time="invalid")
 
 
 def test_from_dict():
     data = {
-        "num_cpus": 4,
-        "num_gpus": 1,
+        "cpus": 4,
+        "gpus": 1,
         "memory": "16GB",
-        "wall_time": "2:00:00",
+        "time": "2:00:00",
         "partition": "gpu",
     }
     res = Resources.from_dict(data)
-    assert res.num_cpus == 4
-    assert res.num_gpus == 1
+    assert res.cpus == 4
+    assert res.gpus == 1
     assert res.memory == "16GB"
-    assert res.wall_time == "2:00:00"
+    assert res.time == "2:00:00"
     assert res.partition == "gpu"
 
 
 def test_to_slurm_options():
-    res = Resources(num_cpus=4, memory="16GB", wall_time="2:00:00")
+    res = Resources(cpus=4, memory="16GB", time="2:00:00")
     assert res.to_slurm_options() == "--cpus-per-task=4 --mem=16GB --time=2:00:00"
 
-    res = res.update(partition="gpu", num_gpus=2)
+    res = res.update(partition="gpu", gpus=2)
     assert (
         res.to_slurm_options()
         == "--cpus-per-task=4 --gres=gpu:2 --mem=16GB --time=2:00:00 --partition=gpu"
@@ -78,10 +78,10 @@ def test_to_slurm_options():
 
 
 def test_update():
-    res = Resources(num_cpus=4, memory="16GB", wall_time="2:00:00")
-    res = res.update(partition="high", num_gpus=2)
+    res = Resources(cpus=4, memory="16GB", time="2:00:00")
+    res = res.update(partition="high", gpus=2)
     assert res.partition == "high"
-    assert res.num_gpus == 2
+    assert res.gpus == 2
     assert (
         res.to_slurm_options()
         == "--cpus-per-task=4 --gres=gpu:2 --mem=16GB --time=2:00:00 --partition=high"
@@ -100,20 +100,20 @@ def test_combine_max_empty_list():
 
 
 def test_combine_max_single_resource():
-    res = Resources(num_cpus=4, memory="16GB", wall_time="2:00:00")
+    res = Resources(cpus=4, memory="16GB", time="2:00:00")
     combined_res = Resources.combine_max([res])
     assert combined_res == res
 
 
 def test_combine_max_none_values():
-    res1 = Resources(num_cpus=4, memory="16GB")
-    res2 = Resources(num_gpus=1, wall_time="2:00:00")
+    res1 = Resources(cpus=4, memory="16GB")
+    res2 = Resources(gpus=1, time="2:00:00")
 
     combined_res = Resources.combine_max([res1, res2])
-    assert combined_res.num_cpus == 4
-    assert combined_res.num_gpus == 1
+    assert combined_res.cpus == 4
+    assert combined_res.gpus == 1
     assert combined_res.memory == "16GB"
-    assert combined_res.wall_time == "2:00:00"
+    assert combined_res.time == "2:00:00"
     assert combined_res.partition is None
 
 
@@ -127,16 +127,16 @@ def test_combine_max_extra_args():
 
 
 def test_combine_max_multiple_resources():
-    res1 = Resources(num_cpus=4, memory="16GB", wall_time="2:00:00")
-    res2 = Resources(num_cpus=2, memory="32GB", wall_time="4:00:00")
-    res3 = Resources(num_gpus=1, memory="8GB", wall_time="1:00:00", partition="gpu")
+    res1 = Resources(cpus=4, memory="16GB", time="2:00:00")
+    res2 = Resources(cpus=2, memory="32GB", time="4:00:00")
+    res3 = Resources(gpus=1, memory="8GB", time="1:00:00", partition="gpu")
 
     combined_res = Resources.combine_max([res1, res2, res3])
     assert combined_res == Resources(
-        num_cpus=4,
-        num_gpus=1,
+        cpus=4,
+        gpus=1,
         memory="32GB",
-        wall_time="4:00:00",
+        time="4:00:00",
         partition="gpu",
     )
 
@@ -151,55 +151,55 @@ def test_combine_max_memory_units():
 
 
 def test_invalid_num_nodes():
-    with pytest.raises(ValueError, match="num_nodes must be a positive integer."):
-        Resources(num_nodes=0)
+    with pytest.raises(ValueError, match="nodes must be a positive integer."):
+        Resources(nodes=0)
 
-    with pytest.raises(ValueError, match="num_nodes must be a positive integer."):
-        Resources(num_nodes=-1)
+    with pytest.raises(ValueError, match="nodes must be a positive integer."):
+        Resources(nodes=-1)
 
 
 def test_invalid_num_cpus_per_node():
-    with pytest.raises(ValueError, match="num_cpus_per_node must be a positive integer."):
-        Resources(num_cpus_per_node=0)
+    with pytest.raises(ValueError, match="cpus_per_node must be a positive integer."):
+        Resources(cpus_per_node=0)
 
-    with pytest.raises(ValueError, match="num_cpus_per_node must be a positive integer."):
-        Resources(num_cpus_per_node=-1)
+    with pytest.raises(ValueError, match="cpus_per_node must be a positive integer."):
+        Resources(cpus_per_node=-1)
 
 
 def test_num_cpus_and_num_nodes_conflict():
-    with pytest.raises(ValueError, match="num_nodes and num_cpus cannot be specified together."):
-        Resources(num_cpus=4, num_nodes=2)
+    with pytest.raises(ValueError, match="nodes and cpus cannot be specified together."):
+        Resources(cpus=4, nodes=2)
 
 
 def test_num_cpus_per_node_without_num_nodes():
     with pytest.raises(
         ValueError,
-        match="num_cpus_per_node must be specified with num_nodes.",
+        match="cpus_per_node must be specified with nodes.",
     ):
-        Resources(num_cpus_per_node=4)
+        Resources(cpus_per_node=4)
 
 
 def test_update_method():
     # Create an initial Resources instance
     initial_resources = Resources(
-        num_cpus=4,
+        cpus=4,
         memory="16GB",
-        wall_time="2:00:00",
+        time="2:00:00",
         extra_args={"key1": "value1"},
     )
 
     # Update existing attributes and add new extra arguments
     updated_resources = initial_resources.update(
-        num_cpus=8,
+        cpus=8,
         memory="32GB",
         extra_args={"key2": "value2"},
         new_key="new_value",
     )
 
     # Check that the existing attributes are updated correctly
-    assert updated_resources.num_cpus == 8
+    assert updated_resources.cpus == 8
     assert updated_resources.memory == "32GB"
-    assert updated_resources.wall_time == "2:00:00"
+    assert updated_resources.time == "2:00:00"
 
     # Check that the extra arguments are updated and new ones are added
     assert updated_resources.extra_args == {
@@ -209,28 +209,28 @@ def test_update_method():
     }
 
     # Check that the original resources instance is not modified
-    assert initial_resources.num_cpus == 4
+    assert initial_resources.cpus == 4
     assert initial_resources.memory == "16GB"
     assert initial_resources.extra_args == {"key1": "value1"}
 
 
 def test_resources_wrong_args():
     with pytest.raises(TypeError, match="The following arguments are allowed"):
-        Resources.from_dict({"num_cpus": 4, "wrong_arg": 1})
+        Resources.from_dict({"cpus": 4, "wrong_arg": 1})
 
 
 def test_num_cpus_per_node():
-    r = Resources(num_cpus_per_node=1, num_nodes=1)
-    assert r.num_cpus_per_node == 1
+    r = Resources(cpus_per_node=1, nodes=1)
+    assert r.cpus_per_node == 1
     assert r.to_slurm_options() == "--nodes=1 --cpus-per-node=1"
 
 
 def test_combine_with_defaults():
-    r = Resources(num_cpus_per_node=1, num_nodes=1)
-    defaults = Resources(partition="partition-1", num_nodes=2)
+    r = Resources(cpus_per_node=1, nodes=1)
+    defaults = Resources(partition="partition-1", nodes=2)
     combined = r.with_defaults(defaults)
-    assert combined.num_cpus_per_node == 1
-    assert combined.num_nodes == 1
+    assert combined.cpus_per_node == 1
+    assert combined.nodes == 1
     assert combined.partition == "partition-1"
     combined = r.with_defaults(None)
     assert combined is r


### PR DESCRIPTION
### Comparison Table

| **Current Name**    | **Proposed Name** | **SLURM** | **Kubernetes** | **Apache Spark** | **TensorFlow** | **Dask** |
|---------------------|-------------------|-----------|----------------|------------------|----------------|----------|
| `num_cpus`          | `cpus`            | `--cpus-per-task` | `cpu`          | `spark.executor.cores`, `spark.task.cpus` | -                | `nthreads`|
| `num_gpus`          | `gpus`            | `--gres=gpu`      | `nvidia.com/gpu` | `num_gpus`          | `num_gpus` | -        |
| `num_nodes`         | `nodes`           | `--nodes`         | -              | `spark.executor.instances` | -          | -        |
| `num_cpus_per_node` | `cpus_per_node`   | `--cpus-per-node` | -              | -                | -          | -        |
| `memory`            | `memory`          | `--mem`           | `memory`       | `spark.executor.memory`   | -          | `memory_limit`|
| `wall_time`         | `time`            | `--time`          | -              | -                | -          | -        |
| `partition`         | `partition`       | `--partition`     | -              | -                | -          | -        |
| `extra_args`        | `extra_args`      | -                 | -              | -                | -          | -        |

Based on the comparison, the proposed names are quite consistent with common conventions across different frameworks. The names like `cpus`, `gpus`, `nodes`, `memory`, and `time` are intuitive and align well with both industry standards and user expectations.