### PR TITLE
Try getting type-hints instead of allowing to error out

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Whether you're working with data processing, scientific computations, machine le
 8. 🔍 **Parameter Sweep Utilities**: Generate parameter combinations for parameter sweeps and optimize the sweeps with result caching.
 9. 💡 **Flexible Function Arguments**: Call functions with different argument combinations, letting `pipefunc` determine which other functions to call based on the provided arguments.
 10. 🏗️ **Leverages giants**: Builds on top of [NetworkX](https://networkx.org/) for graph algorithms, [NumPy](https://numpy.org/) for multi-dimensional arrays, and optionally [Xarray](https://docs.xarray.dev/) for labeled multi-dimensional arrays, [Zarr](https://zarr.readthedocs.io/) to store results in memory/disk/cloud or any key-value store, and [Adaptive](https://adaptive.readthedocs.io/) for parallel sweeps.
-11. 🤓 **Nerd stats**: >400 tests with 100% test coverage, fully typed, only 4 required dependencies, *all* Ruff Rules, *all* public API documented.
+11. 🤓 **Nerd stats**: >500 tests with 100% test coverage, fully typed, only 4 required dependencies, *all* Ruff Rules, *all* public API documented.
 
 ## :test_tube: How does it work?
 

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -659,6 +659,8 @@ class PipeFunc(Generic[T]):
         func = self.func
         if isinstance(func, _NestedFuncWrapper):
             func = func.func
+        if inspect.isclass(func):
+            func = func.__init__
         type_hints = safe_get_type_hints(func, include_extras=True)
         return {self.renames.get(k, k): v for k, v in type_hints.items() if k != "return"}
 
@@ -668,6 +670,8 @@ class PipeFunc(Generic[T]):
         func = self.func
         if isinstance(func, _NestedFuncWrapper):
             func = func.func
+        if inspect.isclass(func) and isinstance(self.output_name, str):
+            return {self.output_name: func}
         if self._output_picker is None:
             hint = safe_get_type_hints(func, include_extras=True).get("return", NoAnnotation)
         else:

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -659,7 +659,7 @@ class PipeFunc(Generic[T]):
         func = self.func
         if isinstance(func, _NestedFuncWrapper):
             func = func.func
-        type_hints = safe_get_type_hints(func)
+        type_hints = safe_get_type_hints(func, include_extras=True)
         return {self.renames.get(k, k): v for k, v in type_hints.items() if k != "return"}
 
     @functools.cached_property
@@ -669,7 +669,7 @@ class PipeFunc(Generic[T]):
         if isinstance(func, _NestedFuncWrapper):
             func = func.func
         if self._output_picker is None:
-            hint = safe_get_type_hints(func).get("return", NoAnnotation)
+            hint = safe_get_type_hints(func, include_extras=True).get("return", NoAnnotation)
         else:
             # We cannot determine the output type if a custom output picker
             # is used, however, if the output is a tuple and the _default_output_picker

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -660,7 +660,7 @@ class PipeFunc(Generic[T]):
         func = self.func
         if isinstance(func, _NestedFuncWrapper):
             func = func.func
-        type_hints = get_type_hints(func, include_extras=True)
+        type_hints = _try_get_type_hints(func)
         return {self.renames.get(k, k): v for k, v in type_hints.items() if k != "return"}
 
     @functools.cached_property
@@ -670,7 +670,7 @@ class PipeFunc(Generic[T]):
         if isinstance(func, _NestedFuncWrapper):
             func = func.func
         if self._output_picker is None:
-            hint = get_type_hints(func, include_extras=True).get("return", NoAnnotation)
+            hint = _try_get_type_hints(func).get("return", NoAnnotation)
         else:
             # We cannot determine the output type if a custom output picker
             # is used, however, if the output is a tuple and the _default_output_picker
@@ -1236,3 +1236,10 @@ def _maybe_update_kwargs_with_resources(
             kwargs[resources_variable] = resources(kwargs)
         else:
             kwargs[resources_variable] = resources
+
+
+def _try_get_type_hints(func: Callable[..., Any]) -> dict[str, Any]:
+    try:
+        return get_type_hints(func, include_extras=True)
+    except NameError:
+        return {}

--- a/pipefunc/typing.py
+++ b/pipefunc/typing.py
@@ -257,10 +257,13 @@ class Unresolvable:
         return False
 
 
-def safe_get_type_hints(func: Callable[..., Any]) -> dict[str, Any]:
+def safe_get_type_hints(
+    func: Callable[..., Any],
+    include_extras: bool = False,  # noqa: FBT001, FBT002
+) -> dict[str, Any]:
     """Safely get type hints for a function, resolving forward references."""
     try:
-        hints = get_type_hints(func)
+        hints = get_type_hints(func, include_extras=include_extras)
     except Exception:  # noqa: BLE001
         hints = func.__annotations__
 
@@ -269,9 +272,7 @@ def safe_get_type_hints(func: Callable[..., Any]) -> dict[str, Any]:
     for arg, hint in hints.items():
         try:
             resolved_hints[arg] = _resolve_type(hint, memo)
-        except NameError:  # noqa: PERF203
+        except (NameError, Exception):  # noqa: PERF203
             resolved_hints[arg] = Unresolvable(str(hint))
-        except Exception:  # noqa: BLE001
-            resolved_hints[arg] = hint
 
     return resolved_hints

--- a/pipefunc/typing.py
+++ b/pipefunc/typing.py
@@ -66,13 +66,11 @@ def _resolve_type(type_: Any, memo: TypeCheckMemo) -> Any:
     if isinstance(type_, ForwardRef):
         return _evaluate_forwardref(type_, memo)
     origin = get_origin(type_)
-    if origin in {Union, UnionType}:  # Handle both Union and new | syntax
-        args = get_args(type_)
-        resolved_args = tuple(_resolve_type(arg, memo) for arg in args)
-        return Union[resolved_args]  # noqa: UP007
     if origin:
         args = get_args(type_)
         resolved_args = tuple(_resolve_type(arg, memo) for arg in args)
+        if origin in {Union, UnionType}:  # Handle both Union and new | syntax
+            return Union[resolved_args]  # noqa: UP007
         return origin[resolved_args]  # Ensure correct subscripting for generic types
     return type_
 

--- a/tests/test_pipefunc_annotations.py
+++ b/tests/test_pipefunc_annotations.py
@@ -73,3 +73,14 @@ def test_multi_output():
 
     assert _mapspec_with_internal_shape(generate_ints, double_it, "x")
     assert _mapspec_with_internal_shape(generate_ints, double_it, "y")
+
+
+def test_pipefunc_from_class():
+    class Adder:
+        def __init__(self, a: int) -> None:
+            self.a = a
+
+    adder_func = PipeFunc(Adder, output_name="sum")
+    assert isinstance(adder_func(a=1), Adder)
+    assert adder_func.parameter_annotations == {"a": int}
+    assert adder_func.output_annotation == {"sum": Adder}

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -260,84 +260,70 @@ def test_compatible_types_with_multiple_annotated_fields():
 
 
 def test_safe_get_type_hints_basic_types():
-    def func(a: int, b: str) -> None:
+    def func(a: int, b: str) -> None:  # noqa: ARG001
         pass
 
     expected = {
         "a": int,
         "b": str,
-        "return": type(None),
+        "return": None,
     }
     assert safe_get_type_hints(func) == expected
 
 
 def test_safe_get_type_hints_forward_ref():
-    def func(a: UndefinedType) -> None:
+    def func(a: UndefinedType) -> None:  # type: ignore[name-defined]  # noqa: ARG001, F821
         pass
 
     expected = {
         "a": Unresolvable("UndefinedType"),
-        "return": type(None),
+        "return": None,
     }
     assert safe_get_type_hints(func) == expected
 
 
 def test_safe_get_type_hints_generic_type():
-    def func(a: list[int], b: str | None) -> None:
+    def func(a: list[int], b: str | None) -> None:  # type: ignore[name-defined]  # noqa: ARG001
         pass
 
     expected = {
         "a": list[int],
-        "b": Optional[str],
-        "return": type(None),
+        "b": Optional[str],  # noqa: UP007
+        "return": None,
     }
     assert safe_get_type_hints(func) == expected
 
 
 def test_safe_get_type_hints_mixed_resolved_unresolved():
-    def func(a: UndefinedType, b: int | UndefinedType) -> None:
+    def func(a: UndefinedType, b: int | UndefinedType) -> None:  # type: ignore[name-defined]  # noqa: ARG001, F821
         pass
 
     expected = {
         "a": Unresolvable("UndefinedType"),
-        "b": Union[int, Unresolvable("UndefinedType")],
-        "return": type(None),
+        "b": Unresolvable("int | UndefinedType"),
+        "return": None,
     }
     assert safe_get_type_hints(func) == expected
 
 
-# def test_safe_get_type_hints_with_string_annotations():
-#     from __future__ import annotations
-
-#     def func(a: 'int', b: 'str') -> 'None':
-#         pass
-
-#     expected = {
-#         'a': int,
-#         'b': str,
-#         'return': type(None),
-#     }
-#     assert safe_get_type_hints(func) == expected
-
-
 def test_safe_get_type_hints_unresolvable_generic():
-    def func(a: list[UndefinedType]) -> None:
+    def func(a: list[UndefinedType]) -> None:  # type: ignore[name-defined]  # noqa: ARG001, F821
         pass
 
     expected = {
-        "a": list[Unresolvable("UndefinedType")],
-        "return": type(None),
+        "a": Unresolvable("list[UndefinedType]"),
+        "return": None,
     }
     assert safe_get_type_hints(func) == expected
 
 
 def test_safe_get_type_hints_exception_handling():
-    def func(a: undefined.variable) -> None:
+    def func(a: undefined.variable) -> None:  # type: ignore[name-defined]  # noqa: ARG001, F821
         pass
 
     expected = {
         "a": Unresolvable("undefined.variable"),
-        "return": type(None),
+        "return": None,
     }
     assert safe_get_type_hints(func) == expected
 
@@ -346,30 +332,30 @@ def test_safe_get_type_hints_eval_fallback():
     global SomeType
     SomeType = int
 
-    def func(a: SomeType) -> None:
+    def func(a: SomeType) -> None:  # type: ignore[name-defined] # noqa: ARG001
         pass
 
     expected = {
         "a": SomeType,
-        "return": type(None),
+        "return": None,
     }
     assert safe_get_type_hints(func) == expected
 
 
 def test_safe_get_type_hints_complex_generic():
-    def func(a: list[int] | UndefinedType, b: list[int | str]) -> None:
+    def func(a: list[int] | UndefinedType, b: list[int | str]) -> None:  # type: ignore[name-defined] # noqa: ARG001, F821
         pass
 
     expected = {
-        "a": Union[list[int], Unresolvable("UndefinedType")],
+        "a": Unresolvable("list[int] | UndefinedType"),
         "b": list[int | str],
-        "return": type(None),
+        "return": None,
     }
     assert safe_get_type_hints(func) == expected
 
 
 def test_safe_get_type_hints_no_annotations():
-    def func(a, b):
+    def func(a, b):  # noqa: ARG001
         pass
 
     expected = {}

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Mapping, Sequence
-from typing import Annotated, Any, ForwardRef, Optional, TypeAlias, Union
+from typing import Annotated, Any, ForwardRef, Optional, TypeAlias, Union, get_type_hints
 
 import numpy as np
 import numpy.typing as npt
@@ -18,6 +18,8 @@ from pipefunc.typing import (
     is_type_compatible,
     safe_get_type_hints,
 )
+
+NoneType = type(None)
 
 
 def test_are_types_compatible_standard():
@@ -266,9 +268,10 @@ def test_safe_get_type_hints_basic_types():
     expected = {
         "a": int,
         "b": str,
-        "return": None,
+        "return": NoneType,
     }
     assert safe_get_type_hints(func) == expected
+    assert safe_get_type_hints(func) == get_type_hints(func)
 
 
 def test_safe_get_type_hints_forward_ref():
@@ -277,53 +280,63 @@ def test_safe_get_type_hints_forward_ref():
 
     expected = {
         "a": Unresolvable("UndefinedType"),
-        "return": None,
+        "return": NoneType,
     }
     assert safe_get_type_hints(func) == expected
 
 
 def test_safe_get_type_hints_generic_type():
-    def func(a: list[int], b: str | None) -> None:  # type: ignore[name-defined]  # noqa: ARG001
+    def func(
+        a: list[int],  # noqa: ARG001
+        b: str | None,  # noqa: ARG001
+    ) -> None:
         pass
 
     expected = {
         "a": list[int],
         "b": Optional[str],  # noqa: UP007
-        "return": None,
+        "return": NoneType,
     }
     assert safe_get_type_hints(func) == expected
 
 
 def test_safe_get_type_hints_mixed_resolved_unresolved():
-    def func(a: UndefinedType, b: int | UndefinedType) -> None:  # type: ignore[name-defined]  # noqa: ARG001, F821
+    def func(
+        a: UndefinedType,  # type: ignore[name-defined]  # noqa: ARG001, F821
+        b: int | UndefinedType,  # type: ignore[name-defined]  # noqa: ARG001, F821
+    ) -> None:
         pass
 
     expected = {
         "a": Unresolvable("UndefinedType"),
         "b": Unresolvable("int | UndefinedType"),
-        "return": None,
+        "return": NoneType,
     }
     assert safe_get_type_hints(func) == expected
 
 
 def test_safe_get_type_hints_unresolvable_generic():
-    def func(a: list[UndefinedType]) -> None:  # type: ignore[name-defined]  # noqa: ARG001, F821
+    def func(
+        a: list[UndefinedType],  # type: ignore[name-defined]  # noqa: ARG001, F821
+    ) -> None:
         pass
 
     expected = {
         "a": Unresolvable("list[UndefinedType]"),
-        "return": None,
+        "return": NoneType,
     }
     assert safe_get_type_hints(func) == expected
 
 
 def test_safe_get_type_hints_exception_handling():
-    def func(a: undefined.variable) -> None:  # type: ignore[name-defined]  # noqa: ARG001, F821
+    def func(
+        a: undefined.variable,  # type: ignore[name-defined]  # noqa: ARG001, F821
+    ) -> None:
         pass
 
     expected = {
         "a": Unresolvable("undefined.variable"),
-        "return": None,
+        "return": NoneType,
     }
     assert safe_get_type_hints(func) == expected
 
@@ -337,19 +350,22 @@ def test_safe_get_type_hints_eval_fallback():
 
     expected = {
         "a": SomeType,
-        "return": None,
+        "return": NoneType,
     }
     assert safe_get_type_hints(func) == expected
 
 
 def test_safe_get_type_hints_complex_generic():
-    def func(a: list[int] | UndefinedType, b: list[int | str]) -> None:  # type: ignore[name-defined] # noqa: ARG001, F821
+    def func(
+        a: list[int] | UndefinedType,  # type: ignore[name-defined] # noqa: ARG001, F821
+        b: list[int | str],  # noqa: ARG001
+    ) -> None:
         pass
 
     expected = {
         "a": Unresolvable("list[int] | UndefinedType"),
         "b": list[int | str],
-        "return": None,
+        "return": NoneType,
     }
     assert safe_get_type_hints(func) == expected
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -385,3 +385,19 @@ def test_unresolvable_equality():
     b = Unresolvable("B")
     assert a == a2
     assert a != b
+
+
+def test_safe_get_type_hints_with_annotated():
+    def func(a: Annotated[int, str]) -> None:  # noqa: ARG001
+        pass
+
+    expected1 = {
+        "a": int,
+        "return": NoneType,
+    }
+    expected2 = {
+        "a": Annotated[int, str],
+        "return": NoneType,
+    }
+    assert safe_get_type_hints(func) == expected1
+    assert safe_get_type_hints(func, include_extras=True) == expected2

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -368,6 +368,7 @@ def test_safe_get_type_hints_complex_generic():
         "return": NoneType,
     }
     assert safe_get_type_hints(func) == expected
+    assert str(expected["a"]) == "Unresolvable[list[int] | UndefinedType]"
 
 
 def test_safe_get_type_hints_no_annotations():
@@ -376,3 +377,11 @@ def test_safe_get_type_hints_no_annotations():
 
     expected = {}
     assert safe_get_type_hints(func) == expected
+
+
+def test_unresolvable_equality():
+    a = Unresolvable("A")
+    a2 = Unresolvable("A")
+    b = Unresolvable("B")
+    assert a == a2
+    assert a != b

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -402,3 +402,18 @@ def test_safe_get_type_hints_with_annotated():
     }
     assert safe_get_type_hints(func) == expected1
     assert safe_get_type_hints(func, include_extras=True) == expected2
+
+
+def test_safe_get_type_hints_with_class():
+    class MyClass:
+        def __init__(self, a: int, b: str) -> None:
+            self.a = a
+            self.b = b
+
+    expected = {
+        "a": int,
+        "b": str,
+        "return": NoneType,
+    }
+    assert safe_get_type_hints(MyClass.__init__) == expected
+    assert safe_get_type_hints(MyClass.__init__) == get_type_hints(MyClass.__init__)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -406,6 +406,8 @@ def test_safe_get_type_hints_with_annotated():
 
 def test_safe_get_type_hints_with_class():
     class MyClass:
+        x: int
+
         def __init__(self, a: int, b: str) -> None:
             self.a = a
             self.b = b

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -385,6 +385,7 @@ def test_unresolvable_equality():
     b = Unresolvable("B")
     assert a == a2
     assert a != b
+    assert a != 1
 
 
 def test_safe_get_type_hints_with_annotated():

--- a/tests/test_typing_future_annotations.py
+++ b/tests/test_typing_future_annotations.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from typing import get_type_hints
+
 from pipefunc.typing import safe_get_type_hints
+
+NoneType = type(None)
 
 
 def test_safe_get_type_hints_with_string_annotations():
@@ -10,6 +14,7 @@ def test_safe_get_type_hints_with_string_annotations():
     expected = {
         "a": int,
         "b": str,
-        "return": None,
+        "return": NoneType,
     }
     assert safe_get_type_hints(func) == expected
+    assert safe_get_type_hints(func) == get_type_hints(func)

--- a/tests/test_typing_future_annotations.py
+++ b/tests/test_typing_future_annotations.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pipefunc.typing import safe_get_type_hints
+
+
+def test_safe_get_type_hints_with_string_annotations():
+    def func(a: int, b: str) -> None:  # noqa: ARG001
+        pass
+
+    expected = {
+        "a": int,
+        "b": str,
+        "return": None,
+    }
+    assert safe_get_type_hints(func) == expected


### PR DESCRIPTION
Should try to get the annotations of the variables that can resolve, see 
- https://bugs.python.org/issue43463
- https://peps.python.org/pep-0649/#changes-to-inspect-get-annotations-and-typing-get-type-hints