### PR TITLE
ENH: Allow `pipeline.map` to run without disk

### DIFF
--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -649,8 +649,8 @@ class Pipeline:
             corresponding input data, these are either single values for functions without ``mapspec``
             or lists of values or `numpy.ndarray`s for functions with ``mapspec``.
         run_folder
-            The folder to store the run information. If ``None``, a temporary folder
-            is created.
+            The folder to store the run information. If ``None``, either a temporary folder
+            is created or no folder is used, depending on the storage class.
         internal_shapes
             The shapes for intermediary outputs that cannot be inferred from the inputs.
             You will receive an exception if the shapes cannot be inferred and need to be provided.

--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -650,7 +650,7 @@ class Pipeline:
             or lists of values or `numpy.ndarray`s for functions with ``mapspec``.
         run_folder
             The folder to store the run information. If ``None``, either a temporary folder
-            is created or no folder is used, depending on the storage class.
+            is created or no folder is used, depending on whether the storage class requires serialization.
         internal_shapes
             The shapes for intermediary outputs that cannot be inferred from the inputs.
             You will receive an exception if the shapes cannot be inferred and need to be provided.

--- a/pipefunc/_utils.py
+++ b/pipefunc/_utils.py
@@ -38,6 +38,7 @@ def load(path: Path, *, cache: bool = False) -> Any:
 
 def dump(obj: Any, path: Path) -> None:
     """Dump an object to a path using cloudpickle."""
+    path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("wb") as f:
         cloudpickle.dump(obj, f)
 

--- a/pipefunc/map/_dictarray.py
+++ b/pipefunc/map/_dictarray.py
@@ -224,7 +224,7 @@ class SharedMemoryDictArray(DictArray):
     """Array interface to a shared memory dict store."""
 
     storage_id = "shared_memory_dict"
-    requires_serialization = False
+    requires_serialization = True
 
     def __init__(
         self,

--- a/pipefunc/map/_dictarray.py
+++ b/pipefunc/map/_dictarray.py
@@ -26,7 +26,7 @@ class DictArray(StorageBase):
     """A `numpy.ndarray` backed by a `dict` with internal structure."""
 
     storage_id = "dict"
-    requires_disk = False
+    requires_serialization = False
 
     def __init__(
         self,
@@ -224,7 +224,7 @@ class SharedMemoryDictArray(DictArray):
     """Array interface to a shared memory dict store."""
 
     storage_id = "shared_memory_dict"
-    requires_disk = False
+    requires_serialization = False
 
     def __init__(
         self,

--- a/pipefunc/map/_dictarray.py
+++ b/pipefunc/map/_dictarray.py
@@ -26,6 +26,7 @@ class DictArray(StorageBase):
     """A `numpy.ndarray` backed by a `dict` with internal structure."""
 
     storage_id = "dict"
+    requires_disk = False
 
     def __init__(
         self,
@@ -223,6 +224,7 @@ class SharedMemoryDictArray(DictArray):
     """Array interface to a shared memory dict store."""
 
     storage_id = "shared_memory_dict"
+    requires_disk = False
 
     def __init__(
         self,

--- a/pipefunc/map/_filearray.py
+++ b/pipefunc/map/_filearray.py
@@ -44,7 +44,7 @@ class FileArray(StorageBase):
     """
 
     storage_id = "file_array"
-    requires_disk = True
+    requires_serialization = True
 
     def __init__(
         self,

--- a/pipefunc/map/_filearray.py
+++ b/pipefunc/map/_filearray.py
@@ -44,6 +44,7 @@ class FileArray(StorageBase):
     """
 
     storage_id = "file_array"
+    requires_disk = True
 
     def __init__(
         self,

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -224,7 +224,9 @@ def _func_kwargs(
     for p in func.parameters:
         if p in func._bound:
             kwargs[p] = func._bound[p]
-        elif p in run_info.inputs or p in run_info.all_output_names:
+        elif p in run_info.inputs:
+            kwargs[p] = run_info.inputs[p]
+        elif p in run_info.all_output_names:
             kwargs[p] = _load_from_store(p, store).value
         elif p in run_info.defaults and p not in run_info.all_output_names:
             kwargs[p] = run_info.defaults[p]

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -494,7 +494,7 @@ class _StoredValue(NamedTuple):
     exists: bool
 
 
-def _load_from_store(  # noqa: PLR0912
+def _load_from_store(
     output_name: _OUTPUT_TYPE,
     store: dict[str, StorageBase | Path | DirectValue],
     *,
@@ -528,10 +528,8 @@ def _load_from_store(  # noqa: PLR0912
             msg = f"Unknown storage type: {storage}"
             raise TypeError(msg)
     all_exist = all(exists)
-    if return_output:
-        output = outputs if isinstance(output_name, tuple) else outputs[0]
-        return _StoredValue(output, all_exist)
-    return _StoredValue(None, all_exist)
+    output = (outputs if isinstance(output_name, tuple) else outputs[0]) if return_output else None
+    return _StoredValue(output, all_exist)
 
 
 def _submit_single(

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -138,14 +138,15 @@ class Result(NamedTuple):
     kwargs: dict[str, Any]
     output_name: str
     output: Any
-    store: StorageBase | Path | DirectValue | None
+    store: StorageBase | Path | DirectValue
 
 
 def load_outputs(*output_names: str, run_folder: str | Path) -> Any:
     """Load the outputs of a run."""
     run_folder = Path(run_folder)
     run_info = RunInfo.load(run_folder)
-    outputs = [_load_parameter(output_name, run_info.init_store()) for output_name in output_names]
+    store = run_info.init_store()
+    outputs = [_load_parameter(output_name, store) for output_name in output_names]
     outputs = [_maybe_load_file_array(o) for o in outputs]
     return outputs[0] if len(output_names) == 1 else outputs
 

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -184,7 +184,7 @@ def load_xarray_dataset(
     )
 
 
-def _dump_output(
+def _dump_single_output(
     func: PipeFunc,
     output: Any,
     store: dict[str, StorageBase | Path | DirectValue],
@@ -195,13 +195,13 @@ def _dump_output(
             assert func.output_picker is not None
             _output = func.output_picker(output, output_name)
             new_output.append(_output)
-            _dump_single_output(_output, output_name, store)
+            _single_dump_single_output(_output, output_name, store)
         return tuple(new_output)
-    _dump_single_output(output, func.output_name, store)
+    _single_dump_single_output(output, func.output_name, store)
     return (output,)
 
 
-def _dump_single_output(
+def _single_dump_single_output(
     output: Any,
     output_name: str,
     store: dict[str, StorageBase | Path | DirectValue],
@@ -625,7 +625,7 @@ def _process_task(
         output = tuple(x.reshape(args.shape) for x in args.result_arrays)
     else:
         r = task.result() if executor else task  # type: ignore[union-attr]
-        output = _dump_output(func, r, store)
+        output = _dump_single_output(func, r, store)
 
     # Note that the kwargs still contain the StorageBase objects if _submit_map_spec
     # was used.

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -657,7 +657,7 @@ def _process_task(
             output_name=output_name,
             output=_output,
             store=store[output_name],
-            run_folder=run_folder,
+            run_folder=run_folder,  # TODO: remove run_folder from Result?
         )
         for output_name, _output in zip(at_least_tuple(func.output_name), output)
     }

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -215,11 +215,6 @@ def _dump_single_output(
         storage.value = output
 
 
-def _load_parameter(parameter: str, store: dict[str, StorageBase | Path | DirectValue]) -> Any:
-    r, _ = _load_from_store(parameter, store)
-    return r
-
-
 def _func_kwargs(
     func: PipeFunc,
     run_info: RunInfo,

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -14,22 +14,9 @@ import numpy.typing as npt
 
 from pipefunc._utils import at_least_tuple, dump, handle_error, load, prod
 from pipefunc.cache import HybridCache, to_hashable
-from pipefunc.map._mapspec import (
-    MapSpec,
-    _shape_to_key,
-    validate_consistent_axes,
-)
-from pipefunc.map._run_info import (
-    DirectValue,
-    RunInfo,
-    _external_shape,
-    _internal_shape,
-)
-from pipefunc.map._storage_base import (
-    StorageBase,
-    _iterate_shape_indices,
-    _select_by_mask,
-)
+from pipefunc.map._mapspec import MapSpec, _shape_to_key, validate_consistent_axes
+from pipefunc.map._run_info import DirectValue, RunInfo, _external_shape, _internal_shape
+from pipefunc.map._storage_base import StorageBase, _iterate_shape_indices, _select_by_mask
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Sequence
@@ -112,8 +99,6 @@ def run(
     _validate_complete_inputs(pipeline, inputs)
     validate_consistent_axes(pipeline.mapspecs(ordered=False))
     _validate_fixed_indices(fixed_indices, inputs, pipeline)
-    if _cannot_be_parallelized(pipeline):
-        parallel = False
     run_info = RunInfo.create(
         run_folder,
         pipeline,
@@ -124,6 +109,8 @@ def run(
     )
     outputs: OrderedDict[str, Result] = OrderedDict()
     store = run_info.init_store()
+    if _cannot_be_parallelized(pipeline):
+        parallel = False
     _check_parallel(parallel, store)
 
     with _maybe_executor(executor, parallel) as ex:

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -202,12 +202,8 @@ def _output_path(output_name: str, run_folder: Path) -> Path:
 def _dump_output(
     func: PipeFunc,
     output: Any,
-    run_folder: Path,
     store: dict[str, StorageBase | Path | dict[str, Any]],
 ) -> tuple[Any, ...]:
-    folder = run_folder / "outputs"
-    folder.mkdir(parents=True, exist_ok=True)
-
     if isinstance(func.output_name, tuple):
         new_output = []  # output in same order as func.output_name
         for output_name in func.output_name:
@@ -650,7 +646,7 @@ def _process_task(
         output = tuple(x.reshape(args.shape) for x in args.result_arrays)
     else:
         r = task.result() if executor else task  # type: ignore[union-attr]
-        output = _dump_output(func, r, run_folder, store)
+        output = _dump_output(func, r, store)
 
     # Note that the kwargs still contain the StorageBase objects if _submit_map_spec
     # was used.

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -64,7 +64,7 @@ def run(
         or lists of values or `numpy.ndarray`s for functions with ``mapspec``.
     run_folder
         The folder to store the run information. If ``None``, either a temporary folder
-        is created or no folder is used, depending on the storage class.
+        is created or no folder is used, depending on whether the storage class requires serialization.
     internal_shapes
         The shapes for intermediary outputs that cannot be inferred from the inputs.
         You will receive an exception if the shapes cannot be inferred and need to be provided.

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -515,7 +515,8 @@ def _load_from_store(
             else:
                 all_exist = False
                 outputs.append(None)
-        elif isinstance(storage, DirectValue):
+        else:
+            assert isinstance(storage, DirectValue)
             if storage.exists():
                 outputs.append(storage.value)
             else:

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -18,6 +18,14 @@ if TYPE_CHECKING:
 _OUTPUT_TYPE: TypeAlias = str | tuple[str, ...]
 
 
+class DirectValue:
+    __slots__ = ["value", "exists"]
+
+    def __init__(self, value: Any | None = None) -> None:
+        self.value = value
+        self.exists = False
+
+
 class Shapes(NamedTuple):
     shapes: dict[_OUTPUT_TYPE, tuple[int, ...]]
     masks: dict[_OUTPUT_TYPE, tuple[bool, ...]]
@@ -114,7 +122,7 @@ class RunInfo:
             raise ValueError(msg)
         return storage_registry[self.storage]
 
-    def init_store(self) -> dict[str, StorageBase | Path | dict[str, Any]]:
+    def init_store(self) -> dict[str, StorageBase | Path | DirectValue]:
         return _init_storage(
             self.all_output_names,
             self.mapspecs,
@@ -288,10 +296,10 @@ def _init_storage(
     shapes: dict[_OUTPUT_TYPE, tuple[int, ...]],
     shape_masks: dict[_OUTPUT_TYPE, tuple[bool, ...]],
     run_folder: Path,
-) -> dict[str, StorageBase | Path | dict[str, Any]]:
+) -> dict[str, StorageBase | Path | DirectValue]:
     from pipefunc.map._run import _output_path
 
-    store: dict[str, StorageBase | Path | dict[str, Any]] = {}
+    store: dict[str, StorageBase | Path | DirectValue] = {}
     for mapspec in mapspecs:
         if not mapspec.inputs:
             continue

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -26,7 +26,7 @@ class _Missing: ...
 class DirectValue:
     __slots__ = ["value"]
 
-    def __init__(self, value: Any | None = _Missing) -> None:
+    def __init__(self, value: Any | type[_Missing] = _Missing) -> None:
         self.value = value
 
     def exists(self) -> bool:

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -140,16 +140,12 @@ class RunInfo:
 
     @property
     def input_paths(self) -> dict[str, Path]:
-        if self.run_folder is None:
-            msg = "Cannot get `input_paths` without `run_folder`."
-            raise ValueError(msg)
+        assert self.run_folder is not None
         return {k: _input_path(k, self.run_folder) for k in self.inputs}
 
     @property
     def defaults_path(self) -> Path:
-        if self.run_folder is None:
-            msg = "Cannot get `defaults_path` without `run_folder`."
-            raise ValueError(msg)
+        assert self.run_folder is not None
         return _default_path(self.run_folder)
 
     @functools.cached_property

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -140,12 +140,16 @@ class RunInfo:
 
     @property
     def input_paths(self) -> dict[str, Path]:
-        assert self.run_folder is not None
+        if self.run_folder is None:
+            msg = "Cannot get `input_paths` without `run_folder`."
+            raise ValueError(msg)
         return {k: _input_path(k, self.run_folder) for k in self.inputs}
 
     @property
     def defaults_path(self) -> Path:
-        assert self.run_folder is not None
+        if self.run_folder is None:
+            msg = "Cannot get `defaults_path` without `run_folder`."
+            raise ValueError(msg)
         return _default_path(self.run_folder)
 
     @functools.cached_property
@@ -243,9 +247,9 @@ def _compare_to_previous_run_info(
         msg = "Internal shapes do not match previous run, cannot use `cleanup=False`."
         raise ValueError(msg)
     if pipeline.mapspecs_as_strings != old.mapspecs_as_strings:
-        msg = "Mapspecs do not match previous run, cannot use `cleanup=False`."
+        msg = "`MapSpec`s do not match previous run, cannot use `cleanup=False`."
         raise ValueError(msg)
-    shapes, masks = map_shapes(pipeline, inputs, internal_shapes)
+    shapes, _masks = map_shapes(pipeline, inputs, internal_shapes)
     if shapes != old.shapes:
         msg = "Shapes do not match previous run, cannot use `cleanup=False`."
         raise ValueError(msg)
@@ -283,11 +287,6 @@ def _maybe_tuple(x: str) -> tuple[str, ...] | str:
     if "," in x:
         return tuple(x.split(","))
     return x
-
-
-def _load_input(name: str, input_paths: dict[str, Path], *, cache: bool = True) -> Any:
-    path = input_paths[name]
-    return load(path, cache=cache)
 
 
 def _output_path(output_name: str, run_folder: Path) -> Path:

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -289,6 +289,10 @@ def _load_input(name: str, input_paths: dict[str, Path], *, cache: bool = True) 
     return load(path, cache=cache)
 
 
+def _output_path(output_name: str, run_folder: Path) -> Path:
+    return run_folder / "outputs" / f"{output_name}.cloudpickle"
+
+
 def _init_storage(
     all_output_names: set[str],
     mapspecs: list[MapSpec],
@@ -297,8 +301,6 @@ def _init_storage(
     shape_masks: dict[_OUTPUT_TYPE, tuple[bool, ...]],
     run_folder: Path,
 ) -> dict[str, StorageBase | Path | DirectValue]:
-    from pipefunc.map._run import _output_path
-
     store: dict[str, StorageBase | Path | DirectValue] = {}
     for mapspec in mapspecs:
         if not mapspec.inputs:

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -165,10 +165,6 @@ class RunInfo:
         if isinstance(self.run_folder, Path):
             defaults_path = _defaults_path(self.run_folder)
             dump(self.defaults, defaults_path)
-            store[_DEFAULTS_KEY] = defaults_path
-        else:
-            store[_DEFAULTS_KEY] = DirectValue(self.defaults)
-
         return store
 
     @property
@@ -229,10 +225,6 @@ class RunInfo:
     @staticmethod
     def path(run_folder: str | Path) -> Path:
         return Path(run_folder) / "run_info.json"
-
-
-# Use a non Python identifier for the key to avoid conflicts with user-defined inputs
-_DEFAULTS_KEY = "#defaults"
 
 
 def _maybe_run_folder(run_folder: str | Path | None, storage: str) -> Path | None:

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -88,7 +88,9 @@ class RunInfo:
         else:
             _compare_to_previous_run_info(pipeline, run_folder, inputs, internal_shapes)
         _check_inputs(pipeline, inputs)
+        # TODO: keep inputs in store too!
         input_paths = _dump_inputs(inputs, run_folder)
+        # TODO: keep defaults in defaults store
         defaults_path = _dump_defaults(pipeline.defaults, run_folder)
         internal_shapes = _construct_internal_shapes(internal_shapes, pipeline)
         shapes, masks = map_shapes(pipeline, inputs, internal_shapes)

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -163,7 +163,7 @@ class RunInfo:
 
         # Set up defaults key with paths or DirectValue
         if isinstance(self.run_folder, Path):
-            defaults_path = _default_path(self.run_folder)
+            defaults_path = _defaults_path(self.run_folder)
             dump(self.defaults, defaults_path)
             store[_DEFAULTS_KEY] = defaults_path
         else:
@@ -183,7 +183,7 @@ class RunInfo:
         if self.run_folder is None:  # pragma: no cover
             msg = "Cannot get `defaults_path` without `run_folder`."
             raise ValueError(msg)
-        return _default_path(self.run_folder)
+        return _defaults_path(self.run_folder)
 
     @functools.cached_property
     def mapspecs(self) -> list[MapSpec]:
@@ -196,8 +196,8 @@ class RunInfo:
         path = self.path(self.run_folder)
         path.parent.mkdir(parents=True, exist_ok=True)
         data = asdict(self)
-        del data["inputs"]
-        del data["defaults"]
+        del data["inputs"]  # Cannot serialize inputs
+        del data["defaults"]  # or defaults
         data["input_paths"] = {k: str(v) for k, v in self.input_paths.items()}
         data["all_output_names"] = sorted(data["all_output_names"])
         for key in ["shapes", "shape_masks"]:
@@ -334,7 +334,7 @@ def _input_path(input_name: str, run_folder: Path) -> Path:
     return run_folder / "inputs" / f"{input_name}.cloudpickle"
 
 
-def _default_path(run_folder: Path) -> Path:
+def _defaults_path(run_folder: Path) -> Path:
     return run_folder / "defaults" / "defaults.cloudpickle"
 
 

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -199,7 +199,7 @@ class RunInfo:
 
 
 def _maybe_run_folder(run_folder: str | Path | None, storage: str) -> Path | None:
-    if run_folder is None and _get_storage_class(storage).requires_disk:
+    if run_folder is None and _get_storage_class(storage).requires_serialization:
         run_folder = tempfile.mkdtemp()
         msg = f"{storage} storage requires a `run_folder`. Using temporary folder: `{run_folder}`."
         warnings.warn(msg, stacklevel=2)

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -291,6 +291,8 @@ def _init_storage(
 
     store: dict[str, StorageBase | Path | dict[str, Any]] = {}
     for mapspec in mapspecs:
+        if not mapspec.inputs:
+            continue
         output_names = mapspec.output_names
         shape = shapes[output_names[0]]
         mask = shape_masks[output_names[0]]

--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -173,14 +173,14 @@ class RunInfo:
 
     @property
     def input_paths(self) -> dict[str, Path]:
-        if self.run_folder is None:
+        if self.run_folder is None:  # pragma: no cover
             msg = "Cannot get `input_paths` without `run_folder`."
             raise ValueError(msg)
         return {k: _input_path(k, self.run_folder) for k in self.inputs}
 
     @property
     def defaults_path(self) -> Path:
-        if self.run_folder is None:
+        if self.run_folder is None:  # pragma: no cover
             msg = "Cannot get `defaults_path` without `run_folder`."
             raise ValueError(msg)
         return _default_path(self.run_folder)
@@ -190,7 +190,7 @@ class RunInfo:
         return [MapSpec.from_string(ms) for ms in self.mapspecs_as_strings]
 
     def dump(self) -> None:
-        if self.run_folder is None:
+        if self.run_folder is None:  # pragma: no cover
             msg = "Cannot dump `RunInfo` without `run_folder`."
             raise ValueError(msg)
         path = self.path(self.run_folder)

--- a/pipefunc/map/_storage_base.py
+++ b/pipefunc/map/_storage_base.py
@@ -50,11 +50,12 @@ class StorageBase(abc.ABC):
     internal_shape: tuple[int, ...]
     shape_mask: tuple[bool, ...]
     storage_id: str
+    requires_disk: bool
 
     @abc.abstractmethod
     def __init__(
         self,
-        folder: str | Path,
+        folder: str | Path | None,
         shape: tuple[int, ...],
         internal_shape: tuple[int, ...] | None = None,
         shape_mask: tuple[bool, ...] | None = None,
@@ -174,3 +175,11 @@ def _normalize_key(
             normalized_key.append(normalized_k)
 
     return tuple(normalized_key)
+
+
+def _get_storage_class(storage: str) -> type[StorageBase]:
+    if storage not in storage_registry:
+        available = ", ".join(storage_registry.keys())
+        msg = f"Storage class `{storage}` not found, only `{available}` available."
+        raise ValueError(msg)
+    return storage_registry[storage]

--- a/pipefunc/map/_storage_base.py
+++ b/pipefunc/map/_storage_base.py
@@ -50,7 +50,7 @@ class StorageBase(abc.ABC):
     internal_shape: tuple[int, ...]
     shape_mask: tuple[bool, ...]
     storage_id: str
-    requires_disk: bool
+    requires_serialization: bool
 
     @abc.abstractmethod
     def __init__(

--- a/pipefunc/map/adaptive.py
+++ b/pipefunc/map/adaptive.py
@@ -383,7 +383,7 @@ class _MapWrapper:
     Copies the Pipeline and removes the cache to avoid issues with the parallel execution.
     """
 
-    mock_pipeline: Pipeline
+    pipeline: Pipeline
     inputs: dict[str, Any]
     run_folder: Path
     internal_shapes: dict[str, int | tuple[int, ...]] | None
@@ -393,7 +393,7 @@ class _MapWrapper:
     def __call__(self, _: Any) -> None:
         """Run the pipeline."""
         run(
-            self.mock_pipeline,  # type: ignore[arg-type]
+            self.pipeline,  # type: ignore[arg-type]
             self.inputs,
             self.run_folder,
             self.internal_shapes,

--- a/pipefunc/map/adaptive.py
+++ b/pipefunc/map/adaptive.py
@@ -393,7 +393,7 @@ class _MapWrapper:
     def __call__(self, _: Any) -> None:
         """Run the pipeline."""
         run(
-            self.pipeline,  # type: ignore[arg-type]
+            self.pipeline,
             self.inputs,
             self.run_folder,
             self.internal_shapes,

--- a/pipefunc/map/adaptive.py
+++ b/pipefunc/map/adaptive.py
@@ -139,6 +139,7 @@ class LearnersDict(LearnersDictType):
         kwargs = details.kwargs()
         if slurm_run_kwargs:
             kwargs.update(slurm_run_kwargs)
+        assert self.run_info.run_folder is not None
         kwargs.setdefault("folder", self.run_info.run_folder / "adaptive_scheduler")
         if returns == "run_manager":  # pragma: no cover
             return details.run_manager(kwargs)
@@ -151,7 +152,7 @@ class LearnersDict(LearnersDictType):
 def create_learners(
     pipeline: Pipeline,
     inputs: dict[str, Any],
-    run_folder: str | Path,
+    run_folder: str | Path | None,
     internal_shapes: dict[str, int | tuple[int, ...]] | None = None,
     *,
     storage: str = "file_array",
@@ -222,7 +223,6 @@ def create_learners(
         ``split_independent_axes`` is ``False``, then the only key is ``None``.
 
     """
-    run_folder = Path(run_folder)
     run_info = RunInfo.create(
         run_folder,
         pipeline,
@@ -231,7 +231,6 @@ def create_learners(
         storage=storage,
         cleanup=cleanup,
     )
-    run_info.dump(run_folder)
     store = run_info.init_store()
     learners: LearnersDict = LearnersDict(run_info=run_info)
     iterator = _maybe_iterate_axes(

--- a/pipefunc/map/adaptive_scheduler.py
+++ b/pipefunc/map/adaptive_scheduler.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from pipefunc._utils import at_least_tuple
-from pipefunc.map._run import _func_kwargs, _load_file_array, _select_kwargs
+from pipefunc.map._run import _func_kwargs, _load_file_arrays, _select_kwargs
 from pipefunc.resources import Resources
 
 if TYPE_CHECKING:
@@ -199,7 +199,7 @@ def _eval_resources(
     run_info: RunInfo,
 ) -> Resources:
     kwargs = _func_kwargs(func, run_info, run_info.init_store())
-    _load_file_array(kwargs)
+    _load_file_arrays(kwargs)
     if index is not None:
         shape = run_info.shapes[func.output_name]
         shape_mask = run_info.shape_masks[func.output_name]

--- a/pipefunc/map/adaptive_scheduler.py
+++ b/pipefunc/map/adaptive_scheduler.py
@@ -82,6 +82,7 @@ def slurm_run_setup(
     assert isinstance(default_resources, Resources) or default_resources is None
     tracker = _ResourcesContainer(default_resources)
     assert learners_dict.run_info is not None
+    assert learners_dict.run_info.run_folder is not None
     run_folder = Path(learners_dict.run_info.run_folder)
     learners: list[SequenceLearner] = []
     fnames: list[Path] = []

--- a/pipefunc/map/zarr.py
+++ b/pipefunc/map/zarr.py
@@ -22,7 +22,7 @@ class ZarrFileArray(StorageBase):
     """Array interface to a Zarr store."""
 
     storage_id = "zarr_file_array"
-    requires_disk = True
+    requires_serialization = True
 
     def __init__(
         self,
@@ -244,7 +244,7 @@ class ZarrMemoryArray(ZarrFileArray):
     """Array interface to an in-memory Zarr store."""
 
     storage_id = "zarr_memory"
-    requires_disk = False
+    requires_serialization = False
 
     def __init__(
         self,
@@ -300,7 +300,7 @@ class ZarrSharedMemoryArray(ZarrMemoryArray):
     """Array interface to a shared memory Zarr store."""
 
     storage_id = "zarr_shared_memory"
-    requires_disk = False
+    requires_serialization = False
 
     def __init__(
         self,

--- a/pipefunc/map/zarr.py
+++ b/pipefunc/map/zarr.py
@@ -300,7 +300,7 @@ class ZarrSharedMemoryArray(ZarrMemoryArray):
     """Array interface to a shared memory Zarr store."""
 
     storage_id = "zarr_shared_memory"
-    requires_serialization = False
+    requires_serialization = True
 
     def __init__(
         self,

--- a/pipefunc/map/zarr.py
+++ b/pipefunc/map/zarr.py
@@ -22,6 +22,7 @@ class ZarrFileArray(StorageBase):
     """Array interface to a Zarr store."""
 
     storage_id = "zarr_file_array"
+    requires_disk = True
 
     def __init__(
         self,
@@ -243,6 +244,7 @@ class ZarrMemoryArray(ZarrFileArray):
     """Array interface to an in-memory Zarr store."""
 
     storage_id = "zarr_memory"
+    requires_disk = False
 
     def __init__(
         self,
@@ -298,6 +300,7 @@ class ZarrSharedMemoryArray(ZarrMemoryArray):
     """Array interface to a shared memory Zarr store."""
 
     storage_id = "zarr_shared_memory"
+    requires_disk = False
 
     def __init__(
         self,

--- a/tests/map/test_adaptive.py
+++ b/tests/map/test_adaptive.py
@@ -24,7 +24,8 @@ if TYPE_CHECKING:
 # Tests with create_learners
 
 
-def test_basic(tmp_path: Path) -> None:
+@pytest.mark.parametrize("storage", ["dict", "file_array"])
+def test_basic(tmp_path: Path, storage: str) -> None:
     @pipefunc(output_name="z")
     def add(x: int, y: int) -> int:
         assert isinstance(x, int)
@@ -43,7 +44,8 @@ def test_basic(tmp_path: Path) -> None:
     learners = create_learners(
         pipeline,
         inputs,
-        run_folder=tmp_path,
+        storage=storage,
+        run_folder=tmp_path if storage == "file_array" else None,
         return_output=True,
     )
     learners.simple_run()
@@ -54,7 +56,8 @@ def test_basic(tmp_path: Path) -> None:
     assert flat_learners["prod"][0].data == {0: 172800}
 
 
-def test_simple_from_step(tmp_path: Path) -> None:
+@pytest.mark.parametrize("storage", ["dict", "file_array"])
+def test_simple_from_step(tmp_path: Path, storage: str) -> None:
     @pipefunc(output_name="x")
     def generate_seeds(n: int) -> list[int]:
         return list(range(n))
@@ -79,7 +82,8 @@ def test_simple_from_step(tmp_path: Path) -> None:
     learners = create_learners(
         pipeline,
         inputs,
-        run_folder=tmp_path,
+        run_folder=tmp_path if storage == "file_array" else None,
+        storage=storage,
         internal_shapes={"x": 4},  # 4 should become (4,)
         return_output=True,
     )
@@ -280,7 +284,8 @@ def test_basic_with_split_independent_axes(tmp_path: Path) -> None:
     ]
 
 
-def test_create_learners_split_axes_with_reduction(tmp_path: Path) -> None:
+@pytest.mark.parametrize("storage", ["dict", "file_array"])
+def test_create_learners_split_axes_with_reduction(tmp_path: Path, storage: str) -> None:
     @pipefunc(output_name="y")
     def double_it(x: int) -> int:
         return 2 * x
@@ -303,7 +308,8 @@ def test_create_learners_split_axes_with_reduction(tmp_path: Path) -> None:
     learners = create_learners(
         pipeline,
         inputs,
-        tmp_path,
+        tmp_path if storage == "file_array" else None,
+        storage=storage,
         return_output=True,
         split_independent_axes=True,
     )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import pickle
 import re
+from typing import TYPE_CHECKING
 
 import pytest
 
 from pipefunc import NestedPipeFunc, PipeFunc, Pipeline, pipefunc
 from pipefunc.exceptions import UnusedParametersError
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_pipeline_and_all_arg_combinations() -> None:
@@ -763,7 +767,7 @@ class Unpicklable:
         raise RuntimeError(msg)
 
 
-def test_unpicklable_run():
+def test_unpicklable_run(tmp_path: Path) -> None:
     @pipefunc(output_name="y")
     def f(a):
         return Unpicklable(a)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pickle
 import re
-from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -781,5 +780,4 @@ def test_unpicklable_run():
             pass
 
     register_storage(LocalDictArray, "local-dict")
-    ex = ThreadPoolExecutor()
-    pipeline.map({}, storage="local-dict", parallel=True, executor=ex)
+    pipeline.map({"a": 1}, storage="local-dict", parallel=False)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,7 +9,6 @@ import pytest
 
 from pipefunc import NestedPipeFunc, PipeFunc, Pipeline, pipefunc
 from pipefunc.exceptions import UnusedParametersError
-from pipefunc.map import DictArray, register_storage
 
 
 def test_pipeline_and_all_arg_combinations() -> None:
@@ -775,9 +774,6 @@ def test_unpicklable_run():
 
     pipeline = Pipeline([f, g])
 
-    class LocalDictArray(DictArray):
-        def persist(self) -> None:
-            pass
-
-    register_storage(LocalDictArray, "local-dict")
-    pipeline.map({"a": 1}, storage="local-dict", parallel=False)
+    r = pipeline.map({"a": 1}, storage="dict", parallel=False)
+    assert isinstance(r["y"].output, Unpicklable)
+    assert r["z"].output == 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced documentation for `run_folder` parameter for better clarity on folder creation.
	- Introduced `requires_serialization` attribute in various classes to clarify serialization needs.
	- Added functionality to ensure parent directories are created before writing files.

- **Bug Fixes**
	- Improved handling of output storage and loading mechanisms to prevent errors.

- **Tests**
	- Parameterized tests to validate functionality across different storage types.
	- Added tests for handling unpicklable objects in the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->