### PR TITLE
FIX: Improve the parallel store compatibility checking function

### DIFF
--- a/pipefunc/_pipeline.py
+++ b/pipefunc/_pipeline.py
@@ -659,7 +659,7 @@ class Pipeline:
         output_names
             The output(s) to calculate. If ``None``, the entire pipeline is run and all outputs are computed.
         parallel
-            Whether to run the functions in parallel.
+            Whether to run the functions in parallel. Is ignored if provided ``executor`` is not ``None``.
         executor
             The executor to use for parallel execution. If ``None``, a `ProcessPoolExecutor`
             is used. Only relevant if ``parallel=True``.

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -657,8 +657,8 @@ def _check_parallel(
     for storage in store.values():
         if isinstance(storage, StorageBase) and not storage.parallelizable:
             recommendation = (
-                "Consider using a file-based storage or `shared_memory` / `zarr_shared_memory`"
-                " for parallel execution or disable parallel execution."
+                "Consider\n - using a file-based storage or `shared_memory` / `zarr_shared_memory`"
+                " for parallel execution,\n - disable parallel execution,\n - or use a different executor.\n"
             )
             default = f"The chosen storage type `{storage.storage_id}` does not support process-based parallel execution."
             if executor is None:
@@ -668,6 +668,7 @@ def _check_parallel(
                     f" {recommendation}"
                 )
                 raise ValueError(msg)
+            assert executor is not None
             msg = (
                 f"{default}"
                 f" If the current executor of type `{type(executor).__name__}` is process-based, it is incompatible."

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -112,7 +112,6 @@ def run(
     store = run_info.init_store()
     if _cannot_be_parallelized(pipeline):
         parallel = False
-
     _check_parallel(parallel, store, executor)
 
     with _maybe_executor(executor, parallel) as ex:

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -658,6 +658,7 @@ def _check_parallel(
         if isinstance(storage, StorageBase) and not storage.parallelizable:
             recommendation = "Use a file based storage or `shared_memory` / `zarr_shared_memory`."
             if executor is None:
+                # PipeFunc will use a ProcessPoolExecutor by default
                 msg = f"Parallel execution is not supported with `{storage.storage_id}` storage. {recommendation}"
                 raise ValueError(msg)
             msg = (


### PR DESCRIPTION
@bra-fsn, this should fix your problem (reported [here](https://github.com/pipefunc/pipefunc/pull/327#issuecomment-2357643505)).

The problem was only with the check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `executor` parameter in the `run` function for enhanced parallel execution control.
	- Added warnings for incompatible storage types with process-based parallel execution.

- **Bug Fixes**
	- Improved error and warning messages for `zarr_memory` storage type regarding parallel execution limitations.

- **Tests**
	- Added a new test for handling unpicklable objects in parallelized mapping.
	- Enhanced existing tests for clarity in error handling and user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->