### PR TITLE
ENH: Allow using memory based storages in parallel too

### DIFF
--- a/pipefunc/map/_prepare.py
+++ b/pipefunc/map/_prepare.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import warnings
 from collections import OrderedDict, defaultdict
-from concurrent.futures import Executor, ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
 from pipefunc._utils import at_least_tuple
@@ -11,9 +9,9 @@ from ._adaptive_scheduler_slurm_executor import validate_slurm_executor
 from ._mapspec import validate_consistent_axes
 from ._progress import init_tracker
 from ._run_info import RunInfo
-from ._storage_array._base import StorageBase
 
 if TYPE_CHECKING:
+    from concurrent.futures import Executor
     from pathlib import Path
 
     from pipefunc import PipeFunc, Pipeline
@@ -98,31 +96,6 @@ def _check_parallel(
             names = uses_default_executor if output_name == "" else at_least_tuple(output_name)
             _check_parallel(parallel, {n: store[n] for n in names}, ex)
         return
-    if isinstance(executor, ThreadPoolExecutor):
-        return
-    if not parallel or not store:
-        return
-    for storage in store.values():
-        if isinstance(storage, StorageBase) and not storage.parallelizable:
-            recommendation = (
-                "Consider\n - using a file-based storage or `shared_memory_dict` / `zarr_shared_memory`"
-                " for parallel execution,\n - disable parallel execution,\n - or use a different executor.\n"
-            )
-            default = f"The chosen storage type `{storage.storage_id}` does not support process-based parallel execution."
-            if executor is None:
-                msg = (
-                    f"{default}"
-                    f" PipeFunc defaults to using a `ProcessPoolExecutor`, which requires a parallelizable storage."
-                    f" {recommendation}"
-                )
-                raise ValueError(msg)
-            assert executor is not None
-            msg = (
-                f"{default}"
-                f" If the current executor of type `{type(executor).__name__}` is process-based, it is incompatible."
-                f" {recommendation}"
-            )
-            warnings.warn(msg, stacklevel=2)
 
 
 def _validate_complete_inputs(pipeline: Pipeline, inputs: dict[str, Any]) -> None:

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -514,7 +514,7 @@ def _update_array(
     # It needs to only dump the data once.
     # If the data can be written during the function call inside the executor (e.g., a file array),
     # we dump it in the executor. Otherwise, we dump it in the main process during the result array update.
-    # We do this to offload the I/O to the executor process if possible.
+    # We do this to offload the I/O and serialization overhead to the executor process if possible.
     assert isinstance(func.mapspec, MapSpec)
     output_key = None
     for array, _output in zip(arrays, outputs):

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -512,13 +512,13 @@ def _update_array(
 ) -> None:
     # This function is called both in the main process (in post processing) and in the executor process.
     # It needs to only dump the data once.
+    # If the data can be written during the function call inside the executor (e.g., a file array),
+    # we dump it in the executor. Otherwise, we dump it in the main process during the result array update.
+    # We do this to offload the I/O to the executor process if possible.
     assert isinstance(func.mapspec, MapSpec)
     output_key = None
     for array, _output in zip(arrays, outputs):
         if force_dump or (array.dump_in_subprocess != in_post_process):
-            # If the data can be written during the function call inside the executor (e.g., a file array),
-            # we dump it in the executor. Otherwise, we dump it in the main process during the result array update.
-            # We do this to offload the I/O to the executor process if possible.
             if output_key is None:  # Only calculate the output key if needed
                 external_shape = external_shape_from_mask(shape, shape_mask)
                 output_key = func.mapspec.output_key(external_shape, index)

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -510,6 +510,8 @@ def _update_array(
     in_post_process: bool,
     force_dump: bool = False,  # Only true in `adaptive.py`
 ) -> None:
+    # This function is called both in the main process (in post processing) and in the executor process.
+    # It needs to only dump the data once.
     assert isinstance(func.mapspec, MapSpec)
     output_key = None
     for array, _output in zip(arrays, outputs):

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -505,6 +505,7 @@ def _update_array(
         if in_executor and array.parallelizable or not in_executor and not array.parallelizable:
             # If the data can be written during the function call inside the executor (e.g., a file array),
             # we dump it in the executor. Otherwise, we dump it in the main process during the result array update.
+            # We do this to offload the I/O to the executor process if possible.
             array.dump(output_key, _output)
 
 

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -515,7 +515,7 @@ def _update_array(
     assert isinstance(func.mapspec, MapSpec)
     output_key = None
     for array, _output in zip(arrays, outputs):
-        if force_dump or (array.parallelizable != in_post_process):
+        if force_dump or (array.dump_in_subprocess != in_post_process):
             # If the data can be written during the function call inside the executor (e.g., a file array),
             # we dump it in the executor. Otherwise, we dump it in the main process during the result array update.
             # We do this to offload the I/O to the executor process if possible.

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -499,10 +499,12 @@ def _update_array(
     in_executor: bool,
 ) -> None:
     assert isinstance(func.mapspec, MapSpec)
-    external_shape = external_shape_from_mask(shape, shape_mask)
-    output_key = func.mapspec.output_key(external_shape, index)
+    output_key = None
     for array, _output in zip(arrays, outputs):
         if in_executor and array.parallelizable or not in_executor and not array.parallelizable:
+            if output_key is None:  # Only calculate the output key if needed
+                external_shape = external_shape_from_mask(shape, shape_mask)
+                output_key = func.mapspec.output_key(external_shape, index)
             # If the data can be written during the function call inside the executor (e.g., a file array),
             # we dump it in the executor. Otherwise, we dump it in the main process during the result array update.
             # We do this to offload the I/O to the executor process if possible.

--- a/pipefunc/map/_storage_array/_base.py
+++ b/pipefunc/map/_storage_array/_base.py
@@ -83,6 +83,10 @@ class StorageBase(abc.ABC):
     def dump(self, key: tuple[int | slice, ...], value: Any) -> None: ...
 
     @property
+    @abc.abstractmethod
+    def parallelizable(self) -> bool: ...
+
+    @property
     def size(self) -> int:
         """Return number of elements in the array."""
         return prod(self.shape)

--- a/pipefunc/map/_storage_array/_base.py
+++ b/pipefunc/map/_storage_array/_base.py
@@ -83,10 +83,6 @@ class StorageBase(abc.ABC):
     def dump(self, key: tuple[int | slice, ...], value: Any) -> None: ...
 
     @property
-    @abc.abstractmethod
-    def parallelizable(self) -> bool: ...
-
-    @property
     def size(self) -> int:
         """Return number of elements in the array."""
         return prod(self.shape)

--- a/pipefunc/map/_storage_array/_base.py
+++ b/pipefunc/map/_storage_array/_base.py
@@ -86,7 +86,6 @@ class StorageBase(abc.ABC):
     @abc.abstractmethod
     def dump_in_subprocess(self) -> bool:
         """Indicates if the storage can be dumped in a subprocess and read by the main process."""
-        return True
 
     @property
     def size(self) -> int:

--- a/pipefunc/map/_storage_array/_base.py
+++ b/pipefunc/map/_storage_array/_base.py
@@ -84,7 +84,9 @@ class StorageBase(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def parallelizable(self) -> bool: ...
+    def dump_in_subprocess(self) -> bool:
+        """Indicates if the storage can be dumped in a subprocess and read by the main process."""
+        return True
 
     @property
     def size(self) -> int:

--- a/pipefunc/map/_storage_array/_dict.py
+++ b/pipefunc/map/_storage_array/_dict.py
@@ -203,8 +203,8 @@ class DictArray(StorageBase):
         self._dict = load(self._path())
 
     @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
+    def dump_in_subprocess(self) -> bool:
+        """Indicates if the storage can be dumped in a subprocess and read by the main process."""
         return False
 
 
@@ -244,8 +244,8 @@ class SharedMemoryDictArray(DictArray):
         )
 
     @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
+    def dump_in_subprocess(self) -> bool:
+        """Indicates if the storage can be dumped in a subprocess and read by the main process."""
         return True
 
 

--- a/pipefunc/map/_storage_array/_dict.py
+++ b/pipefunc/map/_storage_array/_dict.py
@@ -202,11 +202,6 @@ class DictArray(StorageBase):
             return
         self._dict = load(self._path())
 
-    @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
-        return False
-
 
 def _masked_empty(shape: tuple[int, ...]) -> np.ndarray:
     # This is a workaround for the fact that setting `x[:] = np.ma.masked`
@@ -242,11 +237,6 @@ class SharedMemoryDictArray(DictArray):
             shape_mask=shape_mask,
             mapping=mapping,
         )
-
-    @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
-        return True
 
 
 register_storage(DictArray)

--- a/pipefunc/map/_storage_array/_dict.py
+++ b/pipefunc/map/_storage_array/_dict.py
@@ -202,6 +202,11 @@ class DictArray(StorageBase):
             return
         self._dict = load(self._path())
 
+    @property
+    def parallelizable(self) -> bool:
+        """Return whether the storage is parallelizable."""
+        return False
+
 
 def _masked_empty(shape: tuple[int, ...]) -> np.ndarray:
     # This is a workaround for the fact that setting `x[:] = np.ma.masked`
@@ -237,6 +242,11 @@ class SharedMemoryDictArray(DictArray):
             shape_mask=shape_mask,
             mapping=mapping,
         )
+
+    @property
+    def parallelizable(self) -> bool:
+        """Return whether the storage is parallelizable."""
+        return True
 
 
 register_storage(DictArray)

--- a/pipefunc/map/_storage_array/_file.py
+++ b/pipefunc/map/_storage_array/_file.py
@@ -259,8 +259,8 @@ class FileArray(StorageBase):
             dump(value, file)
 
     @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
+    def dump_in_subprocess(self) -> bool:
+        """Indicates if the storage can be dumped in a subprocess and read by the main process."""
         return True
 
 

--- a/pipefunc/map/_storage_array/_file.py
+++ b/pipefunc/map/_storage_array/_file.py
@@ -258,6 +258,11 @@ class FileArray(StorageBase):
             file = self._key_to_file(index)
             dump(value, file)
 
+    @property
+    def parallelizable(self) -> bool:
+        """Return whether the storage is parallelizable."""
+        return True
+
 
 def _read(name: str | Path) -> bytes:
     """Load file contents as a bytestring."""

--- a/pipefunc/map/_storage_array/_file.py
+++ b/pipefunc/map/_storage_array/_file.py
@@ -258,11 +258,6 @@ class FileArray(StorageBase):
             file = self._key_to_file(index)
             dump(value, file)
 
-    @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
-        return True
-
 
 def _read(name: str | Path) -> bytes:
     """Load file contents as a bytestring."""

--- a/pipefunc/map/_storage_array/_zarr.py
+++ b/pipefunc/map/_storage_array/_zarr.py
@@ -210,11 +210,6 @@ class ZarrFileArray(StorageBase):
                 slice_indices.append(range(k, k + 1))
         return slice_indices
 
-    @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
-        return True
-
 
 class _SharedDictStore(zarr.storage.KVStore):
     """Custom Store subclass using a shared dictionary."""
@@ -284,11 +279,6 @@ class ZarrMemoryArray(ZarrFileArray):
             return
         zarr.convenience.copy_store(self.persistent_store, self.store, if_exists="replace")
 
-    @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
-        return False
-
 
 class ZarrSharedMemoryArray(ZarrMemoryArray):
     """Array interface to a shared memory Zarr store."""
@@ -317,11 +307,6 @@ class ZarrSharedMemoryArray(ZarrMemoryArray):
             store=store,
             object_codec=object_codec,
         )
-
-    @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
-        return True
 
 
 class CloudPickleCodec(Codec):

--- a/pipefunc/map/_storage_array/_zarr.py
+++ b/pipefunc/map/_storage_array/_zarr.py
@@ -210,6 +210,11 @@ class ZarrFileArray(StorageBase):
                 slice_indices.append(range(k, k + 1))
         return slice_indices
 
+    @property
+    def parallelizable(self) -> bool:
+        """Return whether the storage is parallelizable."""
+        return True
+
 
 class _SharedDictStore(zarr.storage.KVStore):
     """Custom Store subclass using a shared dictionary."""
@@ -279,6 +284,11 @@ class ZarrMemoryArray(ZarrFileArray):
             return
         zarr.convenience.copy_store(self.persistent_store, self.store, if_exists="replace")
 
+    @property
+    def parallelizable(self) -> bool:
+        """Return whether the storage is parallelizable."""
+        return False
+
 
 class ZarrSharedMemoryArray(ZarrMemoryArray):
     """Array interface to a shared memory Zarr store."""
@@ -307,6 +317,11 @@ class ZarrSharedMemoryArray(ZarrMemoryArray):
             store=store,
             object_codec=object_codec,
         )
+
+    @property
+    def parallelizable(self) -> bool:
+        """Return whether the storage is parallelizable."""
+        return True
 
 
 class CloudPickleCodec(Codec):

--- a/pipefunc/map/_storage_array/_zarr.py
+++ b/pipefunc/map/_storage_array/_zarr.py
@@ -211,8 +211,8 @@ class ZarrFileArray(StorageBase):
         return slice_indices
 
     @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
+    def dump_in_subprocess(self) -> bool:
+        """Indicates if the storage can be dumped in a subprocess and read by the main process."""
         return True
 
 
@@ -285,8 +285,8 @@ class ZarrMemoryArray(ZarrFileArray):
         zarr.convenience.copy_store(self.persistent_store, self.store, if_exists="replace")
 
     @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
+    def dump_in_subprocess(self) -> bool:
+        """Indicates if the storage can be dumped in a subprocess and read by the main process."""
         return False
 
 
@@ -319,8 +319,8 @@ class ZarrSharedMemoryArray(ZarrMemoryArray):
         )
 
     @property
-    def parallelizable(self) -> bool:
-        """Return whether the storage is parallelizable."""
+    def dump_in_subprocess(self) -> bool:
+        """Indicates if the storage can be dumped in a subprocess and read by the main process."""
         return True
 
 

--- a/pipefunc/map/adaptive.py
+++ b/pipefunc/map/adaptive.py
@@ -381,7 +381,16 @@ def _execute_iteration_in_map_spec(
     kwargs = _func_kwargs(func, run_info, store)
     shape = run_info.shapes[func.output_name]
     mask = run_info.shape_masks[func.output_name]
-    outputs = _run_iteration_and_process(index, func, kwargs, shape, mask, arrays, cache)
+    outputs = _run_iteration_and_process(
+        index,
+        func,
+        kwargs,
+        shape,
+        mask,
+        arrays,
+        cache,
+        force_dump=True,
+    )
     if not return_output:
         return None
     return outputs if isinstance(func.output_name, tuple) else outputs[0]

--- a/tests/map/storage/test_zarr.py
+++ b/tests/map/storage/test_zarr.py
@@ -35,6 +35,7 @@ def test_zarr_array_getitem():
     assert arr[0:1, 0] == {"a": 1}
     assert arr.has_index(0)
     assert not arr.has_index(3)
+    assert arr.parallelizable
 
 
 def test_zarr_array_to_array():

--- a/tests/map/storage/test_zarr.py
+++ b/tests/map/storage/test_zarr.py
@@ -35,7 +35,7 @@ def test_zarr_array_getitem():
     assert arr[0:1, 0] == {"a": 1}
     assert arr.has_index(0)
     assert not arr.has_index(3)
-    assert arr.parallelizable
+    assert arr.dump_in_subprocess
 
 
 def test_zarr_array_to_array():

--- a/tests/map/storage/test_zarr.py
+++ b/tests/map/storage/test_zarr.py
@@ -35,7 +35,6 @@ def test_zarr_array_getitem():
     assert arr[0:1, 0] == {"a": 1}
     assert arr.has_index(0)
     assert not arr.has_index(3)
-    assert arr.parallelizable
 
 
 def test_zarr_array_to_array():

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -104,7 +104,6 @@ def test_simple(storage, tmp_path: Path) -> None:
         pipeline.split_disconnected()
     assert results["y"].store is not None
     assert isinstance(results["y"].store, StorageBase)
-    assert isinstance(results["y"].store.parallelizable, bool)
     assert results["y"].store.has_index(0)
 
 
@@ -862,7 +861,6 @@ def test_from_step_2_dim_array_2(storage: str, tmp_path: Path) -> None:
     assert results["c"].output.shape == (2, 2)
     assert results["c"].store is not None
     assert isinstance(results["c"].store, StorageBase)
-    assert isinstance(results["c"].store.parallelizable, bool)
     assert results["c"].output.tolist() == [[2, 0], [3, -1]]
     assert load_outputs("c", run_folder=tmp_path).tolist() == [[2, 0], [3, -1]]
     load_xarray_dataset(run_folder=tmp_path)

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -104,7 +104,7 @@ def test_simple(storage, tmp_path: Path) -> None:
         pipeline.split_disconnected()
     assert results["y"].store is not None
     assert isinstance(results["y"].store, StorageBase)
-    assert isinstance(results["y"].store.parallelizable, bool)
+    assert isinstance(results["y"].store.dump_in_subprocess, bool)
     assert results["y"].store.has_index(0)
 
 
@@ -862,7 +862,7 @@ def test_from_step_2_dim_array_2(storage: str, tmp_path: Path) -> None:
     assert results["c"].output.shape == (2, 2)
     assert results["c"].store is not None
     assert isinstance(results["c"].store, StorageBase)
-    assert isinstance(results["c"].store.parallelizable, bool)
+    assert isinstance(results["c"].store.dump_in_subprocess, bool)
     assert results["c"].output.tolist() == [[2, 0], [3, -1]]
     assert load_outputs("c", run_folder=tmp_path).tolist() == [[2, 0], [3, -1]]
     load_xarray_dataset(run_folder=tmp_path)

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -104,6 +104,7 @@ def test_simple(storage, tmp_path: Path) -> None:
         pipeline.split_disconnected()
     assert results["y"].store is not None
     assert isinstance(results["y"].store, StorageBase)
+    assert isinstance(results["y"].store.parallelizable, bool)
     assert results["y"].store.has_index(0)
 
 
@@ -861,6 +862,7 @@ def test_from_step_2_dim_array_2(storage: str, tmp_path: Path) -> None:
     assert results["c"].output.shape == (2, 2)
     assert results["c"].store is not None
     assert isinstance(results["c"].store, StorageBase)
+    assert isinstance(results["c"].store.parallelizable, bool)
     assert results["c"].output.tolist() == [[2, 0], [3, -1]]
     assert load_outputs("c", run_folder=tmp_path).tolist() == [[2, 0], [3, -1]]
     load_xarray_dataset(run_folder=tmp_path)

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -1055,11 +1055,8 @@ def test_storage_options_invalid():
 def test_storage_options_zarr_memory_parallel():
     pipeline = Pipeline([PipeFunc(lambda x: x, "y", mapspec="x[i] -> y[i]")])
     inputs = {"x": [1, 2, 3]}
-    with pytest.raises(
-        ValueError,
-        match="The chosen storage type `zarr_memory` does not support process-based parallel execution.",
-    ):
-        pipeline.map(inputs, storage="zarr_memory", parallel=True)
+    result = pipeline.map(inputs, storage="zarr_memory", parallel=True)
+    assert result["y"].output.tolist() == [1, 2, 3]
 
 
 def test_custom_executor():


### PR DESCRIPTION
It turns out that the storages only need to be accessible from the main process because once a function is submitted, it is assumed that its required inputs are known already.