### PR TITLE
BUG: Fix Python≤3.11 case for `handle_error`

### DIFF
--- a/pipefunc/_utils.py
+++ b/pipefunc/_utils.py
@@ -86,7 +86,8 @@ def handle_error(e: Exception, func: Callable, kwargs: dict[str, Any]) -> None:
     call_str = format_function_call(func.__name__, (), kwargs)
     msg = f"Error occurred while executing function `{call_str}`."
     if sys.version_info <= (3, 11):  # pragma: no cover
-        raise type(e)(e.args[0] + msg) from e
+        original_msg = e.args[0] if e.args else ""
+        raise type(e)(original_msg + msg) from e
     e.add_note(msg)
     raise  # noqa: PLE0704
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from pipefunc._utils import (
     format_args,
     format_function_call,
     format_kwargs,
+    handle_error,
     is_min_version,
     load,
     requires,
@@ -253,3 +254,39 @@ def test_is_min_version():
 
     assert is_min_version("numpy", f"{major-1}.{minor}.{patch}")
     assert not is_min_version("numpy", f"{major+1}.{minor}.{patch}")
+
+
+def function_that_raises_empty_args():
+    # Some exceptions can be raised with no arguments
+    raise ValueError
+
+
+def test_handle_error_empty_args(capsys):
+    # We use a context manager to ensure the exception is raised
+    with pytest.raises(ValueError) as exc_info:  # noqa: PT011, PT012
+        try:
+            function_that_raises_empty_args()
+        except Exception as e:  # noqa: BLE001
+            handle_error(e, function_that_raises_empty_args, {})
+
+    # Get the actual error message from the exception
+    error_message = str(exc_info.value)
+    # The message should contain our added text even if original exception was empty
+    msg = "Error occurred while executing function"
+    assert msg in error_message or msg in exc_info.value.__notes__[0]
+    func_name = "function_that_raises_empty_args"
+    assert func_name in error_message or func_name in exc_info.value.__notes__[0]
+
+
+def test_handle_error_with_args():
+    original_message = "Original error message"
+    with pytest.raises(ValueError) as exc_info:  # noqa: PT011, PT012
+        try:
+            raise ValueError(original_message)  # noqa: TRY301
+        except Exception as e:  # noqa: BLE001
+            handle_error(e, function_that_raises_empty_args, {})
+
+    error_message = str(exc_info.value)
+    assert original_message in error_message
+    msg = "Error occurred while executing function"
+    assert msg in error_message or msg in exc_info.value.__notes__[0]


### PR DESCRIPTION
Closes #430. 

cc @thoresma