### PR TITLE
ENH: Remove pygraphviz dependency, was only used in matplotlib plotting backend

### DIFF
--- a/docs/environment-sphinx.yml
+++ b/docs/environment-sphinx.yml
@@ -28,7 +28,6 @@ dependencies:
   - pydantic
   # optional-dependencies: plotting
   - matplotlib
-  - pygraphviz
   - holoviews
   - bokeh
   - python-graphviz

--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,6 @@ dependencies:
   - pydantic
   # optional-dependencies: plotting
   - matplotlib
-  - pygraphviz
   - holoviews
   - bokeh
   - python-graphviz

--- a/pipefunc/_plotting.py
+++ b/pipefunc/_plotting.py
@@ -32,10 +32,10 @@ MAX_LABEL_LENGTH = 20
 def _get_graph_layout(graph: nx.DiGraph) -> dict:
     """Gets the layout of the graph using Graphviz if available, otherwise defaults to a spring layout."""
     try:
-        return graphviz_layout(graph, prog="dot")
+        return graphviz_layout(graph, prog="dot")  # requires pygraphviz
     except ImportError:  # pragma: no cover
         warnings.warn(
-            "Graphviz is not installed. Using spring layout instead.",
+            "pygraphviz is not installed. Using spring layout instead.",
             ImportWarning,
             stacklevel=2,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ zarr = ["zarr"]
 pandas = ["pandas"]
 profiling = ["psutil"]
 pydantic = ["pydantic"]
-plotting = ["matplotlib", "pygraphviz", "holoviews", "bokeh", "graphviz"]
+plotting = ["matplotlib", "holoviews", "bokeh", "graphviz"]
 test = [
     "pytest",
     "pytest-asyncio",


### PR DESCRIPTION
This dependency is also hard to install.