### PR TITLE
TST: Use `pytest-timeout` plugin to prevent handing tests

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -43,4 +43,4 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
             micromamba run -n pipefunc \
-              pytest tests/test_benchmark.py --codspeed --disable-timeout
+              pytest tests/test_benchmark.py --codspeed

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -43,4 +43,4 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
             micromamba run -n pipefunc \
-              pytest tests/test_benchmark.py --codspeed --timeout 0
+              pytest tests/test_benchmark.py --codspeed --disable-timeout

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -30,14 +30,12 @@ jobs:
         uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment.yml
-          cache-environment: true
+          cache-environment: false
 
       - name: Install pipefunc
         shell: bash -l {0}
         run: |
           pip install -e ".[test,all]"
-          # TODO: remove when https://github.com/CodSpeedHQ/pytest-codspeed/issues/59 is fixed
-          micromamba remove -y pytest-timeout
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -30,7 +30,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment.yml
-          cache-environment: false
+          cache-environment: true
 
       - name: Install pipefunc
         shell: bash -l {0}
@@ -43,4 +43,4 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
             micromamba run -n pipefunc \
-              pytest tests/test_benchmark.py --codspeed
+              pytest tests/test_benchmark.py --codspeed --timeout 120

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -45,5 +45,7 @@ jobs:
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
+            set -ex
+            env
             micromamba run -n pipefunc \
               pytest tests/test_benchmark.py --codspeed

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -43,4 +43,4 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
             micromamba run -n pipefunc \
-              pytest tests/test_benchmark.py --codspeed
+              pytest tests/test_benchmark.py --codspeed --timeout 0

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -36,6 +36,9 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -e ".[test,all]"
+          # Otherwise, I get:
+          # INTERNALERROR> ModuleNotFoundError: No module named 'pytest_codspeed.instruments.valgrind._wrapper.dist_callgrind_wrapper'
+          pip uninstall -y pytest-timeout
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -36,16 +36,13 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -e ".[test,all]"
-          # Otherwise, I get:
-          # INTERNALERROR> ModuleNotFoundError: No module named 'pytest_codspeed.instruments.valgrind._wrapper.dist_callgrind_wrapper'
-          pip uninstall -y pytest-timeout
+          # TODO: remove when https://github.com/CodSpeedHQ/pytest-codspeed/issues/59 is fixed
+          micromamba remove -y pytest-timeout
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
-            set -ex
-            env
             micromamba run -n pipefunc \
               pytest tests/test_benchmark.py --codspeed

--- a/docs/environment-sphinx.yml
+++ b/docs/environment-sphinx.yml
@@ -24,7 +24,7 @@ dependencies:
   # optional-dependencies: profiling
   - psutil
   # optional-dependencies: widgets
-  - graphviz-anywidget
+  - graphviz-anywidget>=0.3.0
   - ipywidgets
   # optional-dependencies: xarray
   - xarray

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   # optional-dependencies: profiling
   - psutil
   # optional-dependencies: widgets
-  - graphviz-anywidget
+  - graphviz-anywidget>=0.3.0
   - ipywidgets
   # optional-dependencies: xarray
   - xarray

--- a/environment.yml
+++ b/environment.yml
@@ -35,6 +35,7 @@ dependencies:
   - pytest-asyncio
   - pytest-codspeed
   - pytest-cov
+  - pytest-timeout
   - pytest-xdist
   - pytest
   - versioningit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ test = [
     "pytest-asyncio",
     "pytest-codspeed",
     "pytest-cov",
+    "pytest-timeout",
     "pytest-xdist",
     "pytest",
     "versioningit",
@@ -114,6 +115,7 @@ addopts = """
     --cov-report xml
     --cov-fail-under=35
     --asyncio-mode=strict
+    --timeout 10
 """
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ pandas = ["pandas"]
 plotting = ["bokeh", "graphviz", "holoviews","matplotlib"]
 profiling = ["psutil"]
 pydantic = ["pydantic"]
-widgets = ["graphviz-anywidget", "ipywidgets"]
+widgets = ["graphviz-anywidget>=0.3.0", "ipywidgets"]
 xarray = ["xarray"]
 zarr = ["zarr"]
 test = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ collect_ignore_glob = []
 def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
     # NOTE: This is a workaround for the fact that the pytest-timeout plugin
     # doesn't seem to work with pytest-codspeed.
+    # TODO: remove when https://github.com/CodSpeedHQ/pytest-codspeed/issues/59 is fixed
     if os.getenv("GITHUB_JOB") == "benchmark":
         parser.addoption("--timeout")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,27 @@
 import importlib.util
 import warnings
 
+import _pytest
+
 collect_ignore_glob = []
+
+
+def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
+    # NOTE: This is a workaround for the fact that the pytest-timeout plugin
+    # doesn't seem to work with pytest-codspeed.
+    parser.addoption(
+        "--disable-timeout",
+        action="store_true",
+        default=False,
+        help="Disable the pytest-timeout plugin",
+    )
+
+
+def pytest_configure(config: _pytest.config.Config) -> None:
+    if config.getoption("--disable-timeout"):
+        plugin = config.pluginmanager.getplugin("timeout")
+        assert plugin is not None
+        config.pluginmanager.unregister(plugin)
 
 
 def skip_if_missing(name: str, match: str | None = None) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,17 @@
 import importlib.util
+import os
 import warnings
 
+import _pytest
+
 collect_ignore_glob = []
+
+
+def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
+    # NOTE: This is a workaround for the fact that the pytest-timeout plugin
+    # doesn't seem to work with pytest-codspeed.
+    if os.getenv("GITHUB_JOB") == "benchmark":
+        parser.addoption("--timeout")
 
 
 def skip_if_missing(name: str, match: str | None = None) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,7 @@
 import importlib.util
-import os
 import warnings
 
-import _pytest
-
 collect_ignore_glob = []
-
-
-def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
-    # NOTE: This is a workaround for the fact that the pytest-timeout plugin
-    # doesn't seem to work with pytest-codspeed.
-    # TODO: remove when https://github.com/CodSpeedHQ/pytest-codspeed/issues/59 is fixed
-    if os.getenv("GITHUB_JOB") == "benchmark":
-        parser.addoption("--timeout")
 
 
 def skip_if_missing(name: str, match: str | None = None) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,27 +1,7 @@
 import importlib.util
 import warnings
 
-import _pytest
-
 collect_ignore_glob = []
-
-
-def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
-    # NOTE: This is a workaround for the fact that the pytest-timeout plugin
-    # doesn't seem to work with pytest-codspeed.
-    parser.addoption(
-        "--disable-timeout",
-        action="store_true",
-        default=False,
-        help="Disable the pytest-timeout plugin",
-    )
-
-
-def pytest_configure(config: _pytest.config.Config) -> None:
-    if config.getoption("--disable-timeout"):
-        plugin = config.pluginmanager.getplugin("timeout")
-        assert plugin is not None
-        config.pluginmanager.unregister(plugin)
 
 
 def skip_if_missing(name: str, match: str | None = None) -> None:


### PR DESCRIPTION
Sometimes 3.13t seems to hang until the CI times out after 6 hours. This prevents that.