### PR TITLE
MAINT: Pin `zarr>=2,<3`

### DIFF
--- a/docs/environment-sphinx.yml
+++ b/docs/environment-sphinx.yml
@@ -31,7 +31,7 @@ dependencies:
   # optional-dependencies: xarray
   - xarray
   # optional-dependencies: zarr
-  - zarr
+  - zarr>=2,<3
   # optional-dependencies: docs
   - emoji
   - jupytext

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   # optional-dependencies: xarray
   - xarray
   # optional-dependencies: zarr
-  - zarr
+  - zarr>=2,<3
   # optional-dependencies: test
   - coverage
   - pytest-asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ pydantic = ["pydantic"]
 rich = ["rich"]
 widgets = ["graphviz-anywidget>=0.3.0", "ipywidgets"]
 xarray = ["xarray"]
-zarr = ["zarr"]
+zarr = ["zarr>=2,<3"]
 test = [
     "coverage",
     "pytest-asyncio",


### PR DESCRIPTION
Version 3.0.0 was released and breaks the zarr integration