### PR TITLE
BUG: Fix `NestedPipeFunction` in graph show wrong datatype

### DIFF
--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -771,8 +771,6 @@ class PipeFunc(Generic[T]):
     def output_annotation(self) -> dict[str, Any]:
         """Return the type annotation of the wrapped function's output."""
         func = self.func
-        if isinstance(func, _NestedFuncWrapper):
-            func = func.func
         if inspect.isclass(func) and isinstance(self.output_name, str):
             return {self.output_name: func}
         if self._output_picker is None:
@@ -1228,6 +1226,12 @@ class NestedPipeFunc(PipeFunc):
             )
             for k in sorted(parameters)
         }
+
+    @functools.cached_property
+    def output_annotation(self) -> dict[str, Any]:
+       if isinstance(self._output_name, str):
+            return self.pipeline[self._output_name].output_annotation
+       return tuple([self.pipeline[name].output_annotation for name in at_least_tuple(self._output_name)])
 
     @functools.cached_property
     def _all_outputs(self) -> tuple[str, ...]:

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -1229,11 +1229,10 @@ class NestedPipeFunc(PipeFunc):
 
     @functools.cached_property
     def output_annotation(self) -> dict[str, Any]:
-        if isinstance(self._output_name, str):
-            return self.pipeline[self._output_name].output_annotation
-        return tuple(
-            [self.pipeline[name].output_annotation for name in at_least_tuple(self._output_name)]
-        )
+        return {
+            name: self.pipeline[name].output_annotation[name]
+            for name in at_least_tuple(self._output_name)
+        }
 
     @functools.cached_property
     def _all_outputs(self) -> tuple[str, ...]:

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -1229,9 +1229,11 @@ class NestedPipeFunc(PipeFunc):
 
     @functools.cached_property
     def output_annotation(self) -> dict[str, Any]:
-       if isinstance(self._output_name, str):
+        if isinstance(self._output_name, str):
             return self.pipeline[self._output_name].output_annotation
-       return tuple([self.pipeline[name].output_annotation for name in at_least_tuple(self._output_name)])
+        return tuple(
+            [self.pipeline[name].output_annotation for name in at_least_tuple(self._output_name)]
+        )
 
     @functools.cached_property
     def _all_outputs(self) -> tuple[str, ...]:

--- a/tests/test_nested_pipefunc.py
+++ b/tests/test_nested_pipefunc.py
@@ -328,3 +328,21 @@ def test_nested_pipefunc_variant_different_output_name() -> None:
     pipeline2 = vp2.with_variant({"op": "sub"})
     assert isinstance(pipeline2, Pipeline)
     assert pipeline2(a=1, b=2) == -0.5
+
+
+def test_nested_pipefunc_output_annotation() -> None:
+    @pipefunc(output_name="c")
+    def f1(a, b) -> int:
+        return a + b
+
+    @pipefunc(output_name="d")
+    def f2(c) -> int:
+        return c * 2
+
+    funcs = [f1, f2]
+    nf1 = NestedPipeFunc(funcs, output_name="d")
+    assert nf1.output_annotation == {"d": int}
+    nf1 = NestedPipeFunc(funcs, output_name="c")
+    assert nf1.output_annotation == {"c": int}
+    nf1 = NestedPipeFunc(funcs, output_name=("c", "d"))
+    assert nf1.output_annotation == {"c": int, "d": int}

--- a/tests/test_nested_pipefunc.py
+++ b/tests/test_nested_pipefunc.py
@@ -336,13 +336,13 @@ def test_nested_pipefunc_output_annotation() -> None:
         return a + b
 
     @pipefunc(output_name="d")
-    def f2(c) -> int:
-        return c * 2
+    def f2(c) -> float:
+        return c / 2
 
     funcs = [f1, f2]
     nf1 = NestedPipeFunc(funcs, output_name="d")
-    assert nf1.output_annotation == {"d": int}
+    assert nf1.output_annotation == {"d": float}
     nf1 = NestedPipeFunc(funcs, output_name="c")
     assert nf1.output_annotation == {"c": int}
     nf1 = NestedPipeFunc(funcs, output_name=("c", "d"))
-    assert nf1.output_annotation == {"c": int, "d": int}
+    assert nf1.output_annotation == {"c": int, "d": float}

--- a/tests/test_nested_pipefunc.py
+++ b/tests/test_nested_pipefunc.py
@@ -3,6 +3,7 @@ import pytest
 from pipefunc import ErrorSnapshot, NestedPipeFunc, Pipeline, VariantPipeline, pipefunc
 from pipefunc.map._mapspec import ArraySpec
 from pipefunc.resources import Resources
+from pipefunc.typing import NoAnnotation
 
 
 def test_nested_pipefunc_defaults() -> None:
@@ -11,7 +12,7 @@ def test_nested_pipefunc_defaults() -> None:
         return a + b
 
     @pipefunc(output_name="d")
-    def g(c):
+    def g(c) -> int:
         return c
 
     nf = NestedPipeFunc([f, g])
@@ -21,6 +22,7 @@ def test_nested_pipefunc_defaults() -> None:
     nf.update_defaults({"a": 5, "b": 10})
     assert nf.defaults == {"a": 5, "b": 10}
     assert nf() == (15, 15)
+    assert nf.output_annotation == {"c": NoAnnotation, "d": int}
 
 
 def test_nested_pipefunc_multiple_outputs_defaults() -> None:
@@ -29,12 +31,13 @@ def test_nested_pipefunc_multiple_outputs_defaults() -> None:
         return x, y
 
     @pipefunc(output_name=("out1", "out2"))
-    def i(e, f):
+    def i(e, f) -> tuple[int, int]:
         return e, f
 
     nf2 = NestedPipeFunc([h, i], output_name=("out1", "out2"))
     assert nf2.defaults == {"y": 10}
     assert nf2(x=5) == (5, 10)
+    assert nf2.output_annotation == {"out1": int, "out2": int}
 
 
 def test_nested_pipefunc_bound() -> None:


### PR DESCRIPTION
We cannot resolve the output annotation through the` _NestedPipeFunc.func` property as this is a reference to the `_PipelineAsFunc.call_full_output` method which always annotates the function as `dict[str, Any]`. 

I've added a `output_annotation` property to `NestedPipeFunc` which overwrites the same property of the `PipeFunc` class.
Therefore we can access the `output_annotation` properties of the `PipeFunc`s that constitute the NestedPipeFunc, especially the annotation of the PipeFunc that resembles the output of the `NestedPipeFunc`.

This should resolve  #487.

(There might be an alternative approach by dynamically setting `_PipelineAsFunc.call_full_output` as an attribute with a correct `_PipelineAsFunc.call_full_output.__annotations__` property but I think that the other implementation is a bit cleaner as it seperates the `NestedPipeFunc.output_annotation` logic from the `PipeFunc.output_annotation` logic.)
