### PR TITLE
ENH: Add literals of common storage options to `map` and `map_async` annotations

### DIFF
--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -75,7 +75,7 @@ if TYPE_CHECKING:
     from pipefunc.map._result import Result
     from pipefunc.map._types import UserShapeDict
 
-    from ._types import OUTPUT_TYPE
+    from ._types import OUTPUT_TYPE, StorageType
 
 
 class Pipeline:
@@ -698,12 +698,7 @@ class Pipeline:
         parallel: bool = True,
         executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
         chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int]] | None = None,
-        storage: Literal["file_array", "dict", "shared_memory_dict"]  # noqa: PYI051
-        | str
-        | dict[
-            OUTPUT_TYPE,
-            str | Literal["file_array", "dict", "shared_memory_dict"],  # noqa: PYI051
-        ] = "file_array",
+        storage: StorageType = "file_array",
         persist_memory: bool = True,
         cleanup: bool = True,
         fixed_indices: dict[str, int | slice] | None = None,
@@ -827,12 +822,7 @@ class Pipeline:
         output_names: set[OUTPUT_TYPE] | None = None,
         executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
         chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int]] | None = None,
-        storage: Literal["file_array", "dict", "shared_memory_dict"]  # noqa: PYI051
-        | str
-        | dict[
-            OUTPUT_TYPE,
-            str | Literal["file_array", "dict", "shared_memory_dict"],  # noqa: PYI051
-        ] = "file_array",
+        storage: StorageType = "file_array",
         persist_memory: bool = True,
         cleanup: bool = True,
         fixed_indices: dict[str, int | slice] | None = None,

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -698,7 +698,12 @@ class Pipeline:
         parallel: bool = True,
         executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
         chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int]] | None = None,
-        storage: str | dict[OUTPUT_TYPE, str] = "file_array",
+        storage: Literal["file_array", "dict", "shared_memory_dict"]  # noqa: PYI051
+        | str
+        | dict[
+            OUTPUT_TYPE,
+            str | Literal["file_array", "dict", "shared_memory_dict"],  # noqa: PYI051
+        ] = "file_array",
         persist_memory: bool = True,
         cleanup: bool = True,
         fixed_indices: dict[str, int | slice] | None = None,
@@ -822,7 +827,12 @@ class Pipeline:
         output_names: set[OUTPUT_TYPE] | None = None,
         executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
         chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int]] | None = None,
-        storage: str | dict[OUTPUT_TYPE, str] = "file_array",
+        storage: Literal["file_array", "dict", "shared_memory_dict"]  # noqa: PYI051
+        | str
+        | dict[
+            OUTPUT_TYPE,
+            str | Literal["file_array", "dict", "shared_memory_dict"],  # noqa: PYI051
+        ] = "file_array",
         persist_memory: bool = True,
         cleanup: bool = True,
         fixed_indices: dict[str, int | slice] | None = None,

--- a/pipefunc/_pipeline/_types.py
+++ b/pipefunc/_pipeline/_types.py
@@ -1,3 +1,5 @@
-from typing import TypeAlias
+from typing import Literal, TypeAlias
 
 OUTPUT_TYPE: TypeAlias = str | tuple[str, ...]
+DefaultStorageTypes: TypeAlias = Literal["file_array", "dict", "shared_memory_dict"]
+StorageType: TypeAlias = str | DefaultStorageTypes | dict[OUTPUT_TYPE, DefaultStorageTypes | str]

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from adaptive_scheduler import MultiRunManager
 
     from pipefunc import PipeFunc, Pipeline
-    from pipefunc._pipeline._types import OUTPUT_TYPE
+    from pipefunc._pipeline._types import OUTPUT_TYPE, StorageType
     from pipefunc._widgets import ProgressTracker
     from pipefunc.cache import _CacheBase
 
@@ -65,7 +65,7 @@ def run_map(
     parallel: bool = True,
     executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
     chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int]] | None = None,
-    storage: str | dict[OUTPUT_TYPE, str] = "file_array",
+    storage: StorageType = "file_array",
     persist_memory: bool = True,
     cleanup: bool = True,
     fixed_indices: dict[str, int | slice] | None = None,
@@ -230,7 +230,7 @@ def run_map_async(
     output_names: set[OUTPUT_TYPE] | None = None,
     executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
     chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int]] | None = None,
-    storage: str | dict[OUTPUT_TYPE, str] = "file_array",
+    storage: StorageType = "file_array",
     persist_memory: bool = True,
     cleanup: bool = True,
     fixed_indices: dict[str, int | slice] | None = None,


### PR DESCRIPTION
This feels like a small developer experience improvement to me as I find myself having to look up the available storage_ids every time I'm experimenting with the different storage types. With this literal the language server can already give hints for the "common options". (For completeness, we could also include the zarr options here)

It's required to ignore [PYI051](https://docs.astral.sh/ruff/rules/redundant-literal-union/) here, as a string-literal is technically redundant in a union with str but I think that it's neat to explicitly include the storage types that pipefunc ships with.