### PR TITLE
ENH: Emit warning when `profile=True` and `parallel=True`

### DIFF
--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -87,6 +87,7 @@ class PipeFunc(Generic[T]):
         the renamed argument names.
     profile
         Flag indicating whether the wrapped function should be profiled.
+        Profiling is only available for sequential execution.
     debug
         Flag indicating whether debug information should be printed.
     cache

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -96,6 +96,7 @@ class Pipeline:
     profile
         Flag indicating whether profiling information should be collected.
         If ``None``, the value of each PipeFunc's profile attribute is used.
+        Profiling is only available for sequential execution.
     cache_type
         The type of cache to use. See the notes below for more *important* information.
     cache_kwargs

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -56,6 +56,7 @@ class VariantPipeline:
     profile
         Flag indicating whether profiling information should be collected.
         If ``None``, the value of each PipeFunc's profile attribute is used.
+        Profiling is only available for sequential execution.
     cache_type
         The type of cache to use. See the notes below for more *important* information.
     cache_kwargs

--- a/pipefunc/map/_prepare.py
+++ b/pipefunc/map/_prepare.py
@@ -76,11 +76,8 @@ def prepare_run(
         parallel = False
     _check_parallel(parallel, store, executor)
     if parallel and any(func.profile for func in pipeline.functions):
-        warnings.warn(
-            "`profile=True` is not supported with `parallel=True`.",
-            UserWarning,
-            stacklevel=2,
-        )
+        msg = "`profile=True` is not supported with `parallel=True` using process-based executors."
+        warnings.warn(msg, UserWarning, stacklevel=2)
     return pipeline, run_info, store, outputs, parallel, executor, progress
 
 

--- a/pipefunc/map/_prepare.py
+++ b/pipefunc/map/_prepare.py
@@ -75,7 +75,10 @@ def prepare_run(
     if executor is None and _cannot_be_parallelized(pipeline):
         parallel = False
     _check_parallel(parallel, store, executor)
-    if parallel and pipeline.profile:
+    profile = pipeline.profile is not False and (
+        pipeline.profile or any(func.profile for func in pipeline.functions)
+    )
+    if parallel and profile:
         warnings.warn(
             "`profile=True` is not supported with `parallel=True`.",
             UserWarning,

--- a/pipefunc/map/_prepare.py
+++ b/pipefunc/map/_prepare.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections import OrderedDict, defaultdict
 from typing import TYPE_CHECKING, Any
 
@@ -74,6 +75,12 @@ def prepare_run(
     if executor is None and _cannot_be_parallelized(pipeline):
         parallel = False
     _check_parallel(parallel, store, executor)
+    if parallel and pipeline.profile:
+        warnings.warn(
+            "`profile=True` is not supported with `parallel=True`.",
+            UserWarning,
+            stacklevel=2,
+        )
     return pipeline, run_info, store, outputs, parallel, executor, progress
 
 

--- a/pipefunc/map/_prepare.py
+++ b/pipefunc/map/_prepare.py
@@ -75,10 +75,7 @@ def prepare_run(
     if executor is None and _cannot_be_parallelized(pipeline):
         parallel = False
     _check_parallel(parallel, store, executor)
-    profile = pipeline.profile is not False and (
-        pipeline.profile or any(func.profile for func in pipeline.functions)
-    )
-    if parallel and profile:
+    if parallel and any(func.profile for func in pipeline.functions):
         warnings.warn(
             "`profile=True` is not supported with `parallel=True`.",
             UserWarning,

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -1774,3 +1774,21 @@ def test_nested_pipefunc_map_with_mapspec() -> None:
     results_before = pipeline_copy.map({"a": [1, 2], "b": [3, 4], "x": [5, 6]}, parallel=False)
     results_after = pipeline.map({"a": [1, 2], "b": [3, 4], "x": [5, 6]}, parallel=False)
     assert results_after["e"].output.tolist() == results_before["e"].output.tolist()
+
+
+def test_profiling_and_parallel_unsupported_warning() -> None:
+    @pipefunc("a", mapspec="val[i] -> a[i]")
+    def a(val: int) -> int:
+        return val + 1
+
+    @pipefunc("a", mapspec="val[i] -> a[i]", profile=True)
+    def a_profile(val: int) -> int:
+        return val + 1
+
+    test_pipeline_with_profile_true = Pipeline([a], profile=True)
+    with pytest.warns(UserWarning, match="`profile=True` is not supported with `parallel=True`"):
+        test_pipeline_with_profile_true.map({"val": np.array([1, 2, 3])})
+
+    test_pipeline_with_profile_none = Pipeline([a_profile], profile=None)
+    with pytest.warns(UserWarning, match="`profile=True` is not supported with `parallel=True`"):
+        test_pipeline_with_profile_none.map({"val": np.array([1, 2, 3])})

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -1776,7 +1776,13 @@ def test_nested_pipefunc_map_with_mapspec() -> None:
     assert results_after["e"].output.tolist() == results_before["e"].output.tolist()
 
 
+has_psutil = importlib.util.find_spec("psutil") is not None
+
+
 def test_profiling_and_parallel_unsupported_warning() -> None:
+    if not has_psutil:
+        pytest.skip("psutil not installed")
+
     @pipefunc("a", mapspec="val[i] -> a[i]")
     def a(val: int) -> int:
         return val + 1

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 has_xarray = importlib.util.find_spec("xarray") is not None
 has_ipywidgets = importlib.util.find_spec("ipywidgets") is not None
 has_zarr = importlib.util.find_spec("zarr") is not None
+has_psutil = importlib.util.find_spec("psutil") is not None
 
 storage_options = list(storage_registry)
 
@@ -1776,13 +1777,8 @@ def test_nested_pipefunc_map_with_mapspec() -> None:
     assert results_after["e"].output.tolist() == results_before["e"].output.tolist()
 
 
-has_psutil = importlib.util.find_spec("psutil") is not None
-
-
+@pytest.mark.skipif(not has_psutil, reason="psutil not installed")
 def test_profiling_and_parallel_unsupported_warning() -> None:
-    if not has_psutil:
-        pytest.skip("psutil not installed")
-
     @pipefunc("a", mapspec="val[i] -> a[i]")
     def a(val: int) -> int:
         return val + 1


### PR DESCRIPTION
Added a `UserWarning` to close #547 for now by documenting that profiling only works in sequential mode.