### PR TITLE
ENH: Make `AsyncMap` a `dataclass` instead of `NamedTuple`

### DIFF
--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -191,7 +191,8 @@ def run_map(
     return outputs
 
 
-class AsyncMap(NamedTuple):
+@dataclass
+class AsyncMap:
     task: asyncio.Task[OrderedDict[str, Result]]
     run_info: RunInfo
     progress: ProgressTracker | None


### PR DESCRIPTION
For more informative error messages.