### PR TITLE
ENH: Allow multivariant per PipeFunc (breaking change)

### DIFF
--- a/docs/source/concepts/variants.md
+++ b/docs/source/concepts/variants.md
@@ -29,11 +29,11 @@ Here's a simple example:
 ```{code-cell} ipython3
 from pipefunc import VariantPipeline, pipefunc
 
-@pipefunc(output_name="c", variant="A")
+@pipefunc(output_name="c", variants="A")
 def f(a, b):
     return a + b
 
-@pipefunc(output_name="c", variant="B")
+@pipefunc(output_name="c", variants="B")
 def f_alt(a, b):
     return a - b
 
@@ -53,26 +53,26 @@ pipeline_B = pipeline.with_variant(select="B")
 result_B = pipeline_B(a=2, b=3)  # (2 - 3) * 3 = -3
 ```
 
-For more complex cases, you can group variants using `variant_group`:
+For more complex cases, you can group variants using a dictionary:
 
 ```{code-cell} ipython3
-@pipefunc(output_name="c", variant_group="method", variant="add")
+@pipefunc(output_name="c", variants={"method": "add"})
 def process_A(a, b):
     return a + b
 
-@pipefunc(output_name="b", variant_group="method", variant="sub")
+@pipefunc(output_name="b", variants={"method": "sub"})
 def process_B1(a):
     return a
 
-@pipefunc(output_name="c", variant_group="method", variant="sub")
+@pipefunc(output_name="c", variants={"method": "sub"})
 def process_B2(a, b):
     return a - b
 
-@pipefunc(output_name="d", variant_group="analysis", variant="mul")
+@pipefunc(output_name="d", variants={"analysis": "mul"})
 def analyze_A(b, c):
     return b * c
 
-@pipefunc(output_name="d", variant_group="analysis", variant="div")
+@pipefunc(output_name="d", variants={"analysis": "div"})
 def analyze_B(b, c):
     return b / c
 
@@ -87,7 +87,7 @@ sub_div_pipeline = pipeline.with_variant(
 )
 ```
 
-Here, we see that the `variant_group="method"` in for `variant="add"` will result in a pipeline that takes `a` and `b`, whereas `variant="sub"` will take only `a`.
+Here, we see that the `variants={"method": "add"}` in for `process_A` and `variants={"method": "sub"}` for `process_B1` and `process_B2` define alternative pipelines.
 
 You can visualize the pipelines using the `visualize` method:
 
@@ -110,12 +110,12 @@ pipeline.variants_mapping()
 Variants in the same group can have different output names:
 
 ```{code-cell} ipython3
-@pipefunc(output_name="stats_result", variant_group="analysis", variant="stats")
+@pipefunc(output_name="stats_result", variants={"analysis": "stats"})
 def analyze_stats(data):
     # Perform statistical analysis
     return ...
 
-@pipefunc(output_name="ml_result", variant_group="analysis", variant="ml")
+@pipefunc(output_name="ml_result", variants={"analysis": "ml"})
 def analyze_ml(data):
     # Perform machine learning analysis
     return ...
@@ -131,8 +131,8 @@ result = pipeline_ml("ml_result", data={...})
 
 Key features:
 
-- Define multiple implementations of a function using the `variant` parameter
-- Group related variants using `variant_group`
+- Define multiple implementations of a function using the `variants` parameter
+- Group related variants using dictionary keys in the `variants` parameter
 - Specify defaults with `default_variant`
 - Get a regular `Pipeline` when variants are selected
 - No changes required to your existing functions
@@ -142,7 +142,7 @@ The `with_variant()` method returns either:
 - A regular `Pipeline` if all variants are resolved
 - Another `VariantPipeline` if some variants remain unselected
 
-Also check out {class}`pipefunc.VariantPipeline.from_pipelines` to create a `VariantPipeline` from multiple `Pipeline` objects without having to specify `variant` and `variant_group` for each function.
+Also check out {class}`pipefunc.VariantPipeline.from_pipelines` to create a `VariantPipeline` from multiple `Pipeline` objects without having to specify `variants` for each function.
 
 This makes `VariantPipeline` ideal for:
 

--- a/docs/source/concepts/variants.md
+++ b/docs/source/concepts/variants.md
@@ -131,8 +131,8 @@ result = pipeline_ml("ml_result", data={...})
 
 Key features:
 
-- Define multiple implementations of a function using the `variants` parameter
-- Group related variants using dictionary keys in the `variants` parameter
+- Define multiple implementations of a function using the `variant` parameter
+- Group related variants using dictionary keys in the `variant` parameter
 - Specify defaults with `default_variant`
 - Get a regular `Pipeline` when variants are selected
 - No changes required to your existing functions
@@ -142,7 +142,7 @@ The `with_variant()` method returns either:
 - A regular `Pipeline` if all variants are resolved
 - Another `VariantPipeline` if some variants remain unselected
 
-Also check out {class}`pipefunc.VariantPipeline.from_pipelines` to create a `VariantPipeline` from multiple `Pipeline` objects without having to specify `variants` for each function.
+Also check out {class}`pipefunc.VariantPipeline.from_pipelines` to create a `VariantPipeline` from multiple `Pipeline` objects without having to specify `variant` for each function.
 
 This makes `VariantPipeline` ideal for:
 

--- a/docs/source/concepts/variants.md
+++ b/docs/source/concepts/variants.md
@@ -29,11 +29,11 @@ Here's a simple example:
 ```{code-cell} ipython3
 from pipefunc import VariantPipeline, pipefunc
 
-@pipefunc(output_name="c", variants="A")
+@pipefunc(output_name="c", variant="A")
 def f(a, b):
     return a + b
 
-@pipefunc(output_name="c", variants="B")
+@pipefunc(output_name="c", variant="B")
 def f_alt(a, b):
     return a - b
 
@@ -56,23 +56,23 @@ result_B = pipeline_B(a=2, b=3)  # (2 - 3) * 3 = -3
 For more complex cases, you can group variants using a dictionary:
 
 ```{code-cell} ipython3
-@pipefunc(output_name="c", variants={"method": "add"})
+@pipefunc(output_name="c", variant={"method": "add"})
 def process_A(a, b):
     return a + b
 
-@pipefunc(output_name="b", variants={"method": "sub"})
+@pipefunc(output_name="b", variant={"method": "sub"})
 def process_B1(a):
     return a
 
-@pipefunc(output_name="c", variants={"method": "sub"})
+@pipefunc(output_name="c", variant={"method": "sub"})
 def process_B2(a, b):
     return a - b
 
-@pipefunc(output_name="d", variants={"analysis": "mul"})
+@pipefunc(output_name="d", variant={"analysis": "mul"})
 def analyze_A(b, c):
     return b * c
 
-@pipefunc(output_name="d", variants={"analysis": "div"})
+@pipefunc(output_name="d", variant={"analysis": "div"})
 def analyze_B(b, c):
     return b / c
 
@@ -87,7 +87,7 @@ sub_div_pipeline = pipeline.with_variant(
 )
 ```
 
-Here, we see that the `variants={"method": "add"}` in for `process_A` and `variants={"method": "sub"}` for `process_B1` and `process_B2` define alternative pipelines.
+Here, we see that the `variant={"method": "add"}` in for `process_A` and `variant={"method": "sub"}` for `process_B1` and `process_B2` define alternative pipelines.
 
 You can visualize the pipelines using the `visualize` method:
 
@@ -110,12 +110,12 @@ pipeline.variants_mapping()
 Variants in the same group can have different output names:
 
 ```{code-cell} ipython3
-@pipefunc(output_name="stats_result", variants={"analysis": "stats"})
+@pipefunc(output_name="stats_result", variant={"analysis": "stats"})
 def analyze_stats(data):
     # Perform statistical analysis
     return ...
 
-@pipefunc(output_name="ml_result", variants={"analysis": "ml"})
+@pipefunc(output_name="ml_result", variant={"analysis": "ml"})
 def analyze_ml(data):
     # Perform machine learning analysis
     return ...

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -135,6 +135,20 @@ class PipeFunc(Generic[T]):
         - "element": Allocate resources for each element in the mapspec.
 
         If no mapspec is defined, this parameter is ignored.
+    scope
+        If provided, *all* parameter names and output names of the function will
+        be prefixed with the specified scope followed by a dot (``'.'``), e.g., parameter
+        ``x`` with scope ``foo`` becomes ``foo.x``. This allows multiple functions in a
+        pipeline to have parameters with the same name without conflict. To be selective
+        about which parameters and outputs to include in the scope, use the
+        `PipeFunc.update_scope` method.
+
+        When providing parameter values for functions that have scopes, they can
+        be provided either as a dictionary for the scope, or by using the
+        ``f'{scope}.{name}'`` notation. For example,
+        a `PipeFunc` instance with scope "foo" and "bar", the parameters
+        can be provided as: ``func(foo=dict(a=1, b=2), bar=dict(a=3, b=4))``
+        or ``func(**{"foo.a": 1, "foo.b": 2, "bar.a": 3, "bar.b": 4})``.
     variant
         Identifies this function as an alternative implementation in a
         `VariantPipeline` and specifies which variant groups it belongs to.
@@ -155,21 +169,7 @@ class PipeFunc(Generic[T]):
         variants ("fast"/"accurate"), allowing you to select specific combinations
         like ``{"preprocessing": "v1", "computation": "fast"}``.
     variant_group
-        DEPRECATED in v0.58.0: Use `variant` instead. Specifies the variant group for the function.
-    scope
-        If provided, *all* parameter names and output names of the function will
-        be prefixed with the specified scope followed by a dot (``'.'``), e.g., parameter
-        ``x`` with scope ``foo`` becomes ``foo.x``. This allows multiple functions in a
-        pipeline to have parameters with the same name without conflict. To be selective
-        about which parameters and outputs to include in the scope, use the
-        `PipeFunc.update_scope` method.
-
-        When providing parameter values for functions that have scopes, they can
-        be provided either as a dictionary for the scope, or by using the
-        ``f'{scope}.{name}'`` notation. For example,
-        a `PipeFunc` instance with scope "foo" and "bar", the parameters
-        can be provided as: ``func(foo=dict(a=1, b=2), bar=dict(a=3, b=4))``
-        or ``func(**{"foo.a": 1, "foo.b": 2, "bar.a": 3, "bar.b": 4})``.
+        DEPRECATED in v0.58.0: Use `variant` instead.
 
     Returns
     -------
@@ -219,9 +219,9 @@ class PipeFunc(Generic[T]):
         | None = None,
         resources_variable: str | None = None,
         resources_scope: Literal["map", "element"] = "map",
+        scope: str | None = None,
         variant: str | dict[str | None, str] | None = None,
         variant_group: str | None = None,  # deprecated
-        scope: str | None = None,
     ) -> None:
         """Function wrapper class for pipeline functions with additional attributes."""
         self._pipelines: weakref.WeakSet[Pipeline] = weakref.WeakSet()
@@ -1062,7 +1062,7 @@ def pipefunc(
         variants ("fast"/"accurate"), allowing you to select specific combinations
         like ``{"preprocessing": "v1", "computation": "fast"}``.
     variant_group
-        DEPRECATED in v0.58.0: Use `variant` instead. Specifies the variant group for the function.
+        DEPRECATED in v0.58.0: Use `variant` instead.
 
     Returns
     -------
@@ -1172,7 +1172,7 @@ class NestedPipeFunc(PipeFunc):
         variants ("fast"/"accurate"), allowing you to select specific combinations
         like ``{"preprocessing": "v1", "computation": "fast"}``.
     variant_group
-        DEPRECATED in v0.58.0: Use `variant` instead. Specifies the variant group for the function.
+        DEPRECATED in v0.58.0: Use `variant` instead.
 
     Attributes
     ----------

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -149,7 +149,7 @@ class PipeFunc(Generic[T]):
         a `PipeFunc` instance with scope "foo" and "bar", the parameters
         can be provided as: ``func(foo=dict(a=1, b=2), bar=dict(a=3, b=4))``
         or ``func(**{"foo.a": 1, "foo.b": 2, "bar.a": 3, "bar.b": 4})``.
-    variants
+    variant
         Identifies this function as an alternative implementation in a
         `VariantPipeline` and specifies which variant groups it belongs to.
         When multiple functions share the same `output_name`, variants allow
@@ -217,7 +217,7 @@ class PipeFunc(Generic[T]):
         | None = None,
         resources_variable: str | None = None,
         resources_scope: Literal["map", "element"] = "map",
-        variants: str | dict[str | None, str] | None = None,
+        variant: str | dict[str | None, str] | None = None,
         scope: str | None = None,
     ) -> None:
         """Function wrapper class for pipeline functions with additional attributes."""
@@ -238,7 +238,7 @@ class PipeFunc(Generic[T]):
         self.resources = Resources.maybe_from_dict(resources)
         self.resources_variable = resources_variable
         self.resources_scope: Literal["map", "element"] = resources_scope
-        self.variants = _ensure_variants(variants)
+        self.variant = _ensure_variant(variant)
         self.profiling_stats: ProfilingStats | None
         if scope is not None:
             self.update_scope(scope, inputs="*", outputs="*")
@@ -640,7 +640,7 @@ class PipeFunc(Generic[T]):
             "resources": self.resources,
             "resources_variable": self.resources_variable,
             "resources_scope": self.resources_scope,
-            "variants": self.variants,
+            "variant": self.variant,
         }
         assert_complete_kwargs(kwargs, PipeFunc, skip={"self", "scope"})
         kwargs.update(update)
@@ -946,7 +946,7 @@ def pipefunc(
     resources_variable: str | None = None,
     resources_scope: Literal["map", "element"] = "map",
     scope: str | None = None,
-    variants: str | dict[str | None, str] | None = None,
+    variant: str | dict[str | None, str] | None = None,
 ) -> Callable[[Callable[..., Any]], PipeFunc]:
     """A decorator that wraps a function in a PipeFunc instance.
 
@@ -1036,7 +1036,7 @@ def pipefunc(
         a `PipeFunc` instance with scope "foo" and "bar", the parameters
         can be provided as: ``func(foo=dict(a=1, b=2), bar=dict(a=3, b=4))``
         or ``func(**{"foo.a": 1, "foo.b": 2, "bar.a": 3, "bar.b": 4})``.
-    variants
+    variant
         Identifies this function as an alternative implementation in a
         `VariantPipeline` and specifies which variant groups it belongs to.
         When multiple functions share the same `output_name`, variants allow
@@ -1109,7 +1109,7 @@ def pipefunc(
             resources=resources,
             resources_variable=resources_variable,
             resources_scope=resources_scope,
-            variants=variants,
+            variant=variant,
             scope=scope,
         )
 
@@ -1142,7 +1142,7 @@ class NestedPipeFunc(PipeFunc):
         Same as the `PipeFunc` class. Bind arguments to the functions. These are arguments
         that are fixed. Even when providing different values, the bound values will be
         used. Must be in terms of the renamed argument names.
-    variants
+    variant
         Same as the `PipeFunc` class.
         Identifies this function as an alternative implementation in a
         `VariantPipeline` and specifies which variant groups it belongs to.
@@ -1188,7 +1188,7 @@ class NestedPipeFunc(PipeFunc):
         mapspec: str | MapSpec | None = None,
         resources: dict | Resources | None = None,
         bound: dict[str, Any] | None = None,
-        variants: str | dict[str | None, str] | None = None,
+        variant: str | dict[str | None, str] | None = None,
     ) -> None:
         from pipefunc import Pipeline
 
@@ -1203,7 +1203,7 @@ class NestedPipeFunc(PipeFunc):
         self.function_name = function_name
         self.debug = False  # The underlying PipeFuncs will handle this
         self.cache = any(f.cache for f in self.pipeline.functions)
-        self.variants: dict[str | None, str] = _ensure_variants(variants)
+        self.variant: dict[str | None, str] = _ensure_variant(variant)
         self._output_picker = None
         self._profile = False
         self._renames: dict[str, str] = renames or {}
@@ -1231,7 +1231,7 @@ class NestedPipeFunc(PipeFunc):
             "bound": self._bound,
             "mapspec": self.mapspec,
             "resources": self.resources,
-            "variants": self.variants,
+            "variant": self.variant,
         }
         assert_complete_kwargs(kwargs, NestedPipeFunc, skip={"self"})
         kwargs.update(update)
@@ -1599,9 +1599,9 @@ def _pydantic_defaults(
     return defaults
 
 
-def _ensure_variants(variants: str | dict[str | None, str] | None) -> dict[str | None, str]:
-    """Ensure that the variants are in the correct format."""
+def _ensure_variant(variant: str | dict[str | None, str] | None) -> dict[str | None, str]:
+    """Ensure that the variant is in the correct format."""
     # Convert string variant to dict with None as group
-    if isinstance(variants, str):
-        return {None: variants}
-    return variants or {}
+    if isinstance(variant, str):
+        return {None: variant}
+    return variant or {}

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -358,18 +358,10 @@ class PipeFunc(Generic[T]):
         desired output.
         """
         if self._output_picker is None and isinstance(self.output_name, tuple):
-            return functools.partial(
-                _default_output_picker,
-                output_name=self.output_name,
-            )
+            return functools.partial(_default_output_picker, output_name=self.output_name)
         return self._output_picker
 
-    def update_defaults(
-        self,
-        defaults: dict[str, Any],
-        *,
-        overwrite: bool = False,
-    ) -> None:
+    def update_defaults(self, defaults: dict[str, Any], *, overwrite: bool = False) -> None:
         """Update defaults to the provided keyword arguments.
 
         Parameters
@@ -792,10 +784,7 @@ class PipeFunc(Generic[T]):
         if not inspect.isfunction(func) and not is_classmethod(func):
             func = func.__call__  # type: ignore[operator]
         if self._output_picker is None:
-            hint = safe_get_type_hints(func, include_extras=True).get(
-                "return",
-                NoAnnotation,
-            )
+            hint = safe_get_type_hints(func, include_extras=True).get("return", NoAnnotation)
         else:
             # We cannot determine the output type if a custom output picker
             # is used, however, if the output is a tuple and the _default_output_picker
@@ -1154,7 +1143,25 @@ class NestedPipeFunc(PipeFunc):
         that are fixed. Even when providing different values, the bound values will be
         used. Must be in terms of the renamed argument names.
     variants
-        TODO
+        Same as the `PipeFunc` class.
+        Identifies this function as an alternative implementation in a
+        `VariantPipeline` and specifies which variant groups it belongs to.
+        When multiple functions share the same `output_name`, variants allow
+        selecting which implementation to use during pipeline execution.
+
+        Can be specified in two formats:
+        - A string (e.g., ``"fast"``): Places the function in the default unnamed
+          group (None) with the specified variant name. Equivalent to ``{None: "fast"}``.
+        - A dictionary (e.g., ``{"algorithm": "fast", "optimization": "level1"}``):
+          Assigns the function to multiple variant groups simultaneously, with a
+          specific variant name in each group.
+
+        Functions with the same `output_name` but different variant specifications
+        represent alternative implementations. The {meth}`VariantPipeline.with_variant`
+        method selects which variants to use for execution. For example, you might
+        have "preprocessing" variants ("v1"/"v2") independent from "computation"
+        variants ("fast"/"accurate"), allowing you to select specific combinations
+        like ``{"preprocessing": "v1", "computation": "fast"}``.
 
     Attributes
     ----------

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -645,6 +645,7 @@ class PipeFunc(Generic[T]):
             "resources_variable": self.resources_variable,
             "resources_scope": self.resources_scope,
             "variant": self.variant,
+            "variant_group": None,  # deprecated
         }
         assert_complete_kwargs(kwargs, PipeFunc, skip={"self", "scope"})
         kwargs.update(update)
@@ -1244,6 +1245,7 @@ class NestedPipeFunc(PipeFunc):
             "mapspec": self.mapspec,
             "resources": self.resources,
             "variant": self.variant,
+            "variant_group": None,  # deprecated
         }
         assert_complete_kwargs(kwargs, NestedPipeFunc, skip={"self"})
         kwargs.update(update)

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -1625,7 +1625,7 @@ def _maybe_variant_group_error(
 ) -> None:
     if variant_group is not None:  # TODO: remove in 2025-09
         msg = (
-            "The `variant_group` parameter has been removed."
+            "The `variant_group` parameter has been removed in v0.58.0."
             f" Use the `variant = {{{variant_group!r}: {variant!r}}}` parameter instead."
         )
         raise ValueError(msg)

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -155,7 +155,7 @@ class PipeFunc(Generic[T]):
         variants ("fast"/"accurate"), allowing you to select specific combinations
         like ``{"preprocessing": "v1", "computation": "fast"}``.
     variant_group
-        DEPRECATED: Use `variant` instead. Specifies the variant group for the function.
+        DEPRECATED in v0.58.0: Use `variant` instead. Specifies the variant group for the function.
     scope
         If provided, *all* parameter names and output names of the function will
         be prefixed with the specified scope followed by a dot (``'.'``), e.g., parameter
@@ -1061,7 +1061,7 @@ def pipefunc(
         variants ("fast"/"accurate"), allowing you to select specific combinations
         like ``{"preprocessing": "v1", "computation": "fast"}``.
     variant_group
-        DEPRECATED: Use `variant` instead. Specifies the variant group for the function.
+        DEPRECATED in v0.58.0: Use `variant` instead. Specifies the variant group for the function.
 
     Returns
     -------
@@ -1171,7 +1171,7 @@ class NestedPipeFunc(PipeFunc):
         variants ("fast"/"accurate"), allowing you to select specific combinations
         like ``{"preprocessing": "v1", "computation": "fast"}``.
     variant_group
-        DEPRECATED: Use `variant` instead. Specifies the variant group for the function.
+        DEPRECATED in v0.58.0: Use `variant` instead. Specifies the variant group for the function.
 
     Attributes
     ----------

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -1296,11 +1296,7 @@ class NestedPipeFunc(PipeFunc):
     @functools.cached_property
     def func(self) -> Callable[..., tuple[Any, ...]]:  # type: ignore[override]
         func = self.pipeline.func(self.pipeline.unique_leaf_node.output_name)
-        return _NestedFuncWrapper(
-            func.call_full_output,
-            self._output_name,
-            self.function_name,
-        )
+        return _NestedFuncWrapper(func.call_full_output, self._output_name, self.function_name)
 
     @functools.cached_property
     def __name__(self) -> str:  # type: ignore[override]
@@ -1472,10 +1468,7 @@ def _validate_single_leaf_node(leaf_nodes: list[PipeFunc]) -> None:
         raise ValueError(msg)
 
 
-def _validate_output_name(
-    output_name: OUTPUT_TYPE | None,
-    all_outputs: tuple[str, ...],
-) -> None:
+def _validate_output_name(output_name: OUTPUT_TYPE | None, all_outputs: tuple[str, ...]) -> None:
     if output_name is None:
         return
     if not all(x in all_outputs for x in at_least_tuple(output_name)):

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -272,7 +272,7 @@ class VariantPipeline:
             default_resources=kwargs.get("default_resources", self.default_resources),
         )
 
-    def _resolve_single_variant(self, select: str) -> dict[str, str]:
+    def _resolve_single_variant(self, select: str) -> dict[str | None, str]:
         """Resolve a single variant string to a dictionary."""
         inv = self._variants_mapping_inverse()
         group = inv.get(select, set())
@@ -284,7 +284,7 @@ class VariantPipeline:
             raise ValueError(msg)
         return {group.pop(): select}
 
-    def _select_functions(self, select: dict[str, str]) -> list[PipeFunc]:
+    def _select_functions(self, select: dict[str | None, str]) -> list[PipeFunc]:
         """Select functions based on the given variant selection."""
         new_functions: list[PipeFunc] = []
         for function in self.functions:

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -251,15 +251,9 @@ class VariantPipeline:
             raise TypeError(msg)
 
         # Merge defaults with selection when both are dictionaries and there are missing groups
-        if (
-            isinstance(select, dict)
-            and isinstance(self.default_variant, dict)
-            and set(select.keys()) != set(self.variants_mapping().keys())
-        ):
+        if isinstance(select, dict) and isinstance(self.default_variant, dict):
             # Create merged selection dict (start with defaults, update with explicit selection)
-            complete_select = dict(self.default_variant)
-            complete_select.update(select)
-            select = complete_select
+            select = self.default_variant | select
 
         assert isinstance(select, dict)
         _validate_variants_exist(self.variants_mapping(), select)

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -219,6 +219,8 @@ class VariantPipeline:
             If `select` is a string, it selects a single variant if no ambiguity exists.
             If `select` is a dictionary, it selects a variant for each variant group, where
             the keys are variant group names and the values are variant names.
+            If a partial dictionary is provided (not covering all variant groups) and
+            default_variant is a dictionary, it will merge the defaults with the selection.
         kwargs
             Keyword arguments for changing the parameters for a Pipeline or VariantPipeline.
 
@@ -247,6 +249,18 @@ class VariantPipeline:
         elif not isinstance(select, dict):
             msg = f"Invalid variant type: `{type(select)}`. Expected `str` or `dict`."
             raise TypeError(msg)
+
+        # Merge defaults with selection when both are dictionaries and there are missing groups
+        if (
+            isinstance(select, dict)
+            and isinstance(self.default_variant, dict)
+            and set(select.keys()) != set(self.variants_mapping().keys())
+        ):
+            # Create merged selection dict (start with defaults, update with explicit selection)
+            complete_select = dict(self.default_variant)
+            complete_select.update(select)
+            select = complete_select
+
         assert isinstance(select, dict)
         _validate_variants_exist(self.variants_mapping(), select)
 

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -112,19 +112,19 @@ class VariantPipeline:
 
     Multiple variant groups:
 
-        >>> @pipefunc(output_name="c", variants={"method": "add"})
+        >>> @pipefunc(output_name="c", variant={"method": "add"})
         ... def f1(a, b):
         ...     return a + b
         ...
-        >>> @pipefunc(output_name="c", variants={"method": "sub"})
+        >>> @pipefunc(output_name="c", variant={"method": "sub"})
         ... def f2(a, b):
         ...     return a - b
         ...
-        >>> @pipefunc(output_name="d", variants={"analysis": "mul"})
+        >>> @pipefunc(output_name="d", variant={"analysis": "mul"})
         ... def g1(b, c):
         ...     return b * c
         ...
-        >>> @pipefunc(output_name="d", variants={"analysis": "div"})
+        >>> @pipefunc(output_name="d", variant={"analysis": "div"})
         ... def g2(b, c):
         ...     return b / c
         ...
@@ -191,7 +191,7 @@ class VariantPipeline:
         """Return a dictionary of variant groups and their variants."""
         variant_groups: dict[str | None, set[str]] = {}
         for function in self.functions:
-            for group, variant in function.variants.items():
+            for group, variant in function.variant.items():
                 variants = variant_groups.setdefault(group, set())
                 variants.add(variant)
         return variant_groups
@@ -200,7 +200,7 @@ class VariantPipeline:
         """Return a dictionary of variants and their variant groups."""
         variants: dict[str, set[str | None]] = {}
         for function in self.functions:
-            for group, variant in function.variants.items():
+            for group, variant in function.variant.items():
                 groups = variants.setdefault(variant, set())
                 groups.add(group)
         return variants
@@ -289,7 +289,7 @@ class VariantPipeline:
         new_functions: list[PipeFunc] = []
         for function in self.functions:
             # For functions with no variants, always include them
-            if not function.variants:
+            if not function.variant:
                 new_functions.append(function)
                 continue
 
@@ -297,7 +297,7 @@ class VariantPipeline:
             include = True
 
             # Check variants dict
-            for group, variant in function.variants.items():
+            for group, variant in function.variant.items():
                 if group in select and select[group] != variant:
                     include = False
                     break
@@ -311,7 +311,7 @@ class VariantPipeline:
         """Check if any variants remain after selection."""
         left_over = defaultdict(set)
         for function in functions:
-            for group, variant in function.variants.items():
+            for group, variant in function.variant.items():
                 left_over[group].add(variant)
         return any(len(variants) > 1 for variants in left_over.values())
 
@@ -445,7 +445,7 @@ class VariantPipeline:
             variants_param = {variant_group: variant} if variant_group is not None else variant
 
             unique_funcs = [
-                func.copy(variants=variants_param)
+                func.copy(variant=variants_param)
                 for func in funcs
                 if not _pipefunc_in_list(func, common_funcs)
             ]

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -404,10 +404,10 @@ class VariantPipeline:
         Notes
         -----
         - The `is_identical_pipefunc` function is used to determine if two `PipeFunc`
-        instances are identical.
+          instances are identical.
         - If multiple pipelines contain the same function but with different variant
-        information, the function will be included multiple times in the
-        resulting `VariantPipeline`, each with its respective variant assignment.
+          information, the function will be included multiple times in the
+          resulting `VariantPipeline`, each with its respective variant assignment.
 
         """
         if len(variant_pipeline) < 2:  # noqa: PLR2004

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -33,7 +33,7 @@ class VariantPipeline:
 
     The pipeline can have multiple variant groups, where each group contains alternative
     implementations of a function. Functions can be assigned to variant groups using
-    the ``variants`` parameter which can be a single string (for the default group) or
+    the ``variant`` parameter which can be a single string (for the default group) or
     a dictionary mapping group names to variant names.
 
     All parameters below (except ``functions`` and ``default_variant``) are simply passed to

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -5,12 +5,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Literal
 
 from pipefunc import PipeFunc, Pipeline
-from pipefunc._utils import (
-    assert_complete_kwargs,
-    is_installed,
-    is_running_in_ipynb,
-    requires,
-)
+from pipefunc._utils import assert_complete_kwargs, is_installed, is_running_in_ipynb, requires
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -174,9 +174,7 @@ class VariantPipeline:
     ) -> None:
         """Initialize a VariantPipeline."""
         self.functions = functions
-        self.default_variant: dict[str | None] | None = (
-            default_variant if not isinstance(default_variant, str) else {None: default_variant}
-        )
+        self.default_variant = default_variant
         self.lazy = lazy
         self.debug = debug
         self.profile = profile

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -245,9 +245,7 @@ class VariantPipeline:
             msg = f"Invalid variant type: `{type(select)}`. Expected `str` or `dict`."
             raise TypeError(msg)
 
-        # Merge defaults with selection when both are dictionaries and there are missing groups
-        if isinstance(select, dict) and isinstance(self.default_variant, dict):
-            # Create merged selection dict (start with defaults, update with explicit selection)
+        if isinstance(self.default_variant, dict):
             select = self.default_variant | select
 
         assert isinstance(select, dict)

--- a/tests/test_nested_pipefunc.py
+++ b/tests/test_nested_pipefunc.py
@@ -208,11 +208,11 @@ def test_nested_pipefunc_resources() -> None:
 
 
 def test_nested_pipefunc_variants() -> None:
-    @pipefunc(output_name="c", variants="add")
+    @pipefunc(output_name="c", variant="add")
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants="sub")
+    @pipefunc(output_name="c", variant="sub")
     def f2(a, b):
         return a - b
 
@@ -223,14 +223,14 @@ def test_nested_pipefunc_variants() -> None:
     vp = VariantPipeline([f, f2, g])
     nf = NestedPipeFunc(
         [vp.with_variant("add").functions[0], g],
-        variants="add",
+        variant="add",
     )
-    assert nf.variants == {None: "add"}
+    assert nf.variant == {None: "add"}
     nf2 = NestedPipeFunc(
         [vp.with_variant("sub").functions[0], g],
-        variants="sub",
+        variant="sub",
     )
-    assert nf2.variants == {None: "sub"}
+    assert nf2.variant == {None: "sub"}
 
     vp = VariantPipeline([nf, nf2])
     pipeline_add = vp.with_variant("add")
@@ -242,19 +242,19 @@ def test_nested_pipefunc_variants() -> None:
 
 
 def test_nested_pipefunc_variant_groups() -> None:
-    @pipefunc(output_name="c", variants={"op": "add"})
+    @pipefunc(output_name="c", variant={"op": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op": "sub"})
+    @pipefunc(output_name="c", variant={"op": "sub"})
     def f2(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variants={"mult": "yes"})
+    @pipefunc(output_name="d", variant={"mult": "yes"})
     def g(c):
         return c * 2
 
-    @pipefunc(output_name="d", variants={"mult": "no"})
+    @pipefunc(output_name="d", variant={"mult": "no"})
     def g2(c):
         return c
 
@@ -264,7 +264,7 @@ def test_nested_pipefunc_variant_groups() -> None:
             vp.with_variant({"op": "add", "mult": "yes"}).functions[0],
             vp.with_variant({"op": "add", "mult": "yes"}).functions[1],
         ],
-        variants={"op_mult": "add_yes"},
+        variant={"op_mult": "add_yes"},
     )
 
     nf2 = NestedPipeFunc(
@@ -272,7 +272,7 @@ def test_nested_pipefunc_variant_groups() -> None:
             vp.with_variant({"op": "sub", "mult": "no"}).functions[0],
             vp.with_variant({"op": "sub", "mult": "no"}).functions[1],
         ],
-        variants={"op_mult": "sub_no"},
+        variant={"op_mult": "sub_no"},
     )
 
     vp = VariantPipeline([nf, nf2])
@@ -352,11 +352,11 @@ def test_nested_pipefunc_no_leaf_node() -> None:
 
 
 def test_nested_pipefunc_variant_different_output_name() -> None:
-    @pipefunc(output_name="sum_", variants={"op": "add"})
+    @pipefunc(output_name="sum_", variant={"op": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="diff", variants={"op": "sub"})
+    @pipefunc(output_name="diff", variant={"op": "sub"})
     def f2(a, b):
         return a - b
 
@@ -374,12 +374,12 @@ def test_nested_pipefunc_variant_different_output_name() -> None:
 
     nf = NestedPipeFunc(
         [vp_add.functions[0], vp_add.functions[1]],
-        variants={"op": "add"},
+        variant={"op": "add"},
         output_name="double",
     )
     nf2 = NestedPipeFunc(
         [vp_sub.functions[0], vp_sub.functions[2]],
-        variants={"op": "sub"},
+        variant={"op": "sub"},
         output_name="half",
     )
 

--- a/tests/test_nested_pipefunc.py
+++ b/tests/test_nested_pipefunc.py
@@ -225,12 +225,12 @@ def test_nested_pipefunc_variants() -> None:
         [vp.with_variant("add").functions[0], g],
         variant="add",
     )
-    assert nf.variant == "add"
+    assert nf.variants == {None: "add"}
     nf2 = NestedPipeFunc(
         [vp.with_variant("sub").functions[0], g],
         variant="sub",
     )
-    assert nf2.variant == "sub"
+    assert nf2.variant == {None: "sub"}
 
     vp = VariantPipeline([nf, nf2])
     pipeline_add = vp.with_variant("add")
@@ -242,19 +242,19 @@ def test_nested_pipefunc_variants() -> None:
 
 
 def test_nested_pipefunc_variant_groups() -> None:
-    @pipefunc(output_name="c", variant_group="op", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op"})
     def f2(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variant_group="mult", variant="yes")
+    @pipefunc(output_name="d", variants={"yes": "mult"})
     def g(c):
         return c * 2
 
-    @pipefunc(output_name="d", variant_group="mult", variant="no")
+    @pipefunc(output_name="d", variants={"no": "mult"})
     def g2(c):
         return c
 
@@ -264,8 +264,7 @@ def test_nested_pipefunc_variant_groups() -> None:
             vp.with_variant({"op": "add", "mult": "yes"}).functions[0],
             vp.with_variant({"op": "add", "mult": "yes"}).functions[1],
         ],
-        variant_group="op_mult",
-        variant="add_yes",
+        variants={"add_yes": "op_mult"},
     )
 
     nf2 = NestedPipeFunc(
@@ -273,8 +272,7 @@ def test_nested_pipefunc_variant_groups() -> None:
             vp.with_variant({"op": "sub", "mult": "no"}).functions[0],
             vp.with_variant({"op": "sub", "mult": "no"}).functions[1],
         ],
-        variant_group="op_mult",
-        variant="sub_no",
+        variants={"sub_no": "op_mult"},
     )
 
     vp = VariantPipeline([nf, nf2])
@@ -376,14 +374,12 @@ def test_nested_pipefunc_variant_different_output_name() -> None:
 
     nf = NestedPipeFunc(
         [vp_add.functions[0], vp_add.functions[1]],
-        variant_group="op",
-        variant="add",
+        variants={"op": "add"},
         output_name="double",
     )
     nf2 = NestedPipeFunc(
         [vp_sub.functions[0], vp_sub.functions[2]],
-        variant_group="op",
-        variant="sub",
+        variants={"sub": "op"},
         output_name="half",
     )
 

--- a/tests/test_nested_pipefunc.py
+++ b/tests/test_nested_pipefunc.py
@@ -242,19 +242,19 @@ def test_nested_pipefunc_variants() -> None:
 
 
 def test_nested_pipefunc_variant_groups() -> None:
-    @pipefunc(output_name="c", variants={"add": "op"})
+    @pipefunc(output_name="c", variants={"op": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op"})
+    @pipefunc(output_name="c", variants={"op": "sub"})
     def f2(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variants={"yes": "mult"})
+    @pipefunc(output_name="d", variants={"mult": "yes"})
     def g(c):
         return c * 2
 
-    @pipefunc(output_name="d", variants={"no": "mult"})
+    @pipefunc(output_name="d", variants={"mult": "no"})
     def g2(c):
         return c
 
@@ -264,7 +264,7 @@ def test_nested_pipefunc_variant_groups() -> None:
             vp.with_variant({"op": "add", "mult": "yes"}).functions[0],
             vp.with_variant({"op": "add", "mult": "yes"}).functions[1],
         ],
-        variants={"add_yes": "op_mult"},
+        variants={"op_mult": "add_yes"},
     )
 
     nf2 = NestedPipeFunc(
@@ -272,7 +272,7 @@ def test_nested_pipefunc_variant_groups() -> None:
             vp.with_variant({"op": "sub", "mult": "no"}).functions[0],
             vp.with_variant({"op": "sub", "mult": "no"}).functions[1],
         ],
-        variants={"sub_no": "op_mult"},
+        variants={"op_mult": "sub_no"},
     )
 
     vp = VariantPipeline([nf, nf2])
@@ -374,12 +374,12 @@ def test_nested_pipefunc_variant_different_output_name() -> None:
 
     nf = NestedPipeFunc(
         [vp_add.functions[0], vp_add.functions[1]],
-        variants={"op": "add"},
+        variants={"add": "op"},
         output_name="double",
     )
     nf2 = NestedPipeFunc(
         [vp_sub.functions[0], vp_sub.functions[2]],
-        variants={"sub": "op"},
+        variants={"op": "sub"},
         output_name="half",
     )
 

--- a/tests/test_nested_pipefunc.py
+++ b/tests/test_nested_pipefunc.py
@@ -208,11 +208,11 @@ def test_nested_pipefunc_resources() -> None:
 
 
 def test_nested_pipefunc_variants() -> None:
-    @pipefunc(output_name="c", variant="add")
+    @pipefunc(output_name="c", variants="add")
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant="sub")
+    @pipefunc(output_name="c", variants="sub")
     def f2(a, b):
         return a - b
 
@@ -223,14 +223,14 @@ def test_nested_pipefunc_variants() -> None:
     vp = VariantPipeline([f, f2, g])
     nf = NestedPipeFunc(
         [vp.with_variant("add").functions[0], g],
-        variant="add",
+        variants="add",
     )
     assert nf.variants == {None: "add"}
     nf2 = NestedPipeFunc(
         [vp.with_variant("sub").functions[0], g],
-        variant="sub",
+        variants="sub",
     )
-    assert nf2.variant == {None: "sub"}
+    assert nf2.variants == {None: "sub"}
 
     vp = VariantPipeline([nf, nf2])
     pipeline_add = vp.with_variant("add")
@@ -352,11 +352,11 @@ def test_nested_pipefunc_no_leaf_node() -> None:
 
 
 def test_nested_pipefunc_variant_different_output_name() -> None:
-    @pipefunc(output_name="sum_", variant_group="op", variant="add")
+    @pipefunc(output_name="sum_", variants={"op": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="diff", variant_group="op", variant="sub")
+    @pipefunc(output_name="diff", variants={"op": "sub"})
     def f2(a, b):
         return a - b
 
@@ -374,7 +374,7 @@ def test_nested_pipefunc_variant_different_output_name() -> None:
 
     nf = NestedPipeFunc(
         [vp_add.functions[0], vp_add.functions[1]],
-        variants={"add": "op"},
+        variants={"op": "add"},
         output_name="double",
     )
     nf2 = NestedPipeFunc(

--- a/tests/test_variant_pipeline.py
+++ b/tests/test_variant_pipeline.py
@@ -647,12 +647,12 @@ def test_partial_variant_selection_with_defaults() -> None:
     # Test selecting just one variant group - should use default for the other
     pipeline_sub = pipeline.with_variant(select={"method": "sub"})
     assert isinstance(pipeline_sub, Pipeline)  # Should be a concrete Pipeline
-    assert pipeline_sub(a=2, b=3) == -3  # (2-3)*3 = -3 (using sub for method, mul for analysis)
+    assert pipeline_sub(a=2, b=3) == (2 - 3) * 3  # using sub for method, mul for analysis
 
     # Test selecting the other variant group
     pipeline_div = pipeline.with_variant(select={"analysis": "div"})
     assert isinstance(pipeline_div, Pipeline)
-    assert pipeline_div(a=2, b=3) == 5 / 3  # (2+3)/3 = 5/3 (using add for method, div for analysis)
+    assert pipeline_div(a=2, b=3) == 3 / (2 + 3)  # using add for method, div for analysis
 
 
 def test_partial_default_variant() -> None:
@@ -680,12 +680,12 @@ def test_partial_default_variant() -> None:
     # Test selecting just the other variant group
     pipeline_div = pipeline.with_variant(select={"analysis": "div"})
     assert isinstance(pipeline_div, Pipeline)
-    assert pipeline_div(a=2, b=3) == -1 / 3  # (2-3)/3 = -1/3 (using sub default, div selection)
+    assert pipeline_div(a=2, b=3) == -3 / 1  # using sub default, div selection
 
     # Test overriding the default
     pipeline_add_mul = pipeline.with_variant(select={"method": "add", "analysis": "mul"})
     assert isinstance(pipeline_add_mul, Pipeline)
-    assert pipeline_add_mul(a=2, b=3) == 15  # (2+3)*3 = 15
+    assert pipeline_add_mul(a=2, b=3) == 3 * (2 + 3)
 
 
 def test_variant_selection_edge_cases() -> None:

--- a/tests/test_variant_pipeline.py
+++ b/tests/test_variant_pipeline.py
@@ -13,12 +13,12 @@ has_psutil = importlib.util.find_spec("psutil") is not None
 
 def test_variant_pipeline_single_group() -> None:
     # Define functions with variants and variant groups
-    @pipefunc(output_name="c", variant="add")
+    @pipefunc(output_name="c", variants="add")
     def f(a, b):
         print("Running f (add)")
         return a + b
 
-    @pipefunc(output_name="c", variant="sub")
+    @pipefunc(output_name="c", variants="sub")
     def f_alt(a, b):
         print("Running f_alt (sub)")
         return a - b
@@ -52,22 +52,22 @@ def test_variant_pipeline_single_group() -> None:
 
 def test_variant_pipeline_multiple_groups() -> None:
     # Define functions with variants and variant groups
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         print("Running f (add)")
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         print("Running f_alt (sub)")
         return a - b
 
-    @pipefunc(output_name="d", variant_group="op2", variant="mul")
+    @pipefunc(output_name="d", variants={"mul": "op2"})
     def g(b, c, x=3):
         print("Running g (mul)")
         return b * c * x
 
-    @pipefunc(output_name="d", variant_group="op2", variant="div")
+    @pipefunc(output_name="d", variants={"div": "op2"})
     def g_alt(b, c, x=3):
         print("Running g_alt (div)")
         return b * c / x
@@ -94,11 +94,11 @@ def test_lazy_debug_profile_cache() -> None:
     # We just check that these parameters are passed through to the Pipeline
     # No need to test the actual functionality of these parameters,
     # as they are tested in test_pipeline.py
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
@@ -124,11 +124,11 @@ def test_lazy_debug_profile_cache() -> None:
 
 
 def test_validate_type_annotations() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a: int, b: int) -> int:
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a: int, b: int) -> str:
         return str(a - b)
 
@@ -149,11 +149,11 @@ def test_validate_type_annotations() -> None:
 
 
 def test_error_handling_ambiguous_variant() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op2", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op2"})
     def f_alt(a, b):
         return a - b
 
@@ -164,11 +164,11 @@ def test_error_handling_ambiguous_variant() -> None:
 
 
 def test_error_handling_with_variant() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
@@ -191,15 +191,15 @@ def test_error_handling_with_variant() -> None:
 
 
 def test_variants_mapping_and_inverse() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variant_group="op2", variant="mul")
+    @pipefunc(output_name="d", variants={"mul": "op2"})
     def g(b, c):
         return b * c
 
@@ -222,7 +222,7 @@ def test_variants_mapping_and_inverse() -> None:
 
 
 def test_copy_method() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
@@ -237,7 +237,7 @@ def test_copy_method() -> None:
 
 
 def test_getattr_for_pipeline_attributes() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
@@ -253,26 +253,31 @@ def test_getattr_for_pipeline_attributes() -> None:
 
 
 def test_default_variant() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variant_group="op2", variant="mul")
+    @pipefunc(output_name="d", variants={"mul": "op2"})
     def g(b, c):
         return b * c
 
-    @pipefunc(output_name="d", variant_group="op2", variant="div")
+    @pipefunc(output_name="d", variants={"div": "op2"})
     def g_alt(b, c):
         return b / c
 
     # Test with a single default variant
     pipeline = VariantPipeline([f, f_alt, g, g_alt], default_variant="add")
     pipeline_add = pipeline.with_variant()
-    assert {func.variant for func in pipeline_add.functions} == {"add", "mul", "div"}
+    assert [func.variants for func in pipeline_add.functions] == [
+        {"add": "op1"},
+        {"sub": "op1"},
+        {"mul": "op2"},
+        {"div": "op2"},
+    ]
 
     # Test with a default variant per group
     pipeline = VariantPipeline(
@@ -280,7 +285,7 @@ def test_default_variant() -> None:
         default_variant={"op1": "sub", "op2": "div"},
     )
     pipeline_sub_div = pipeline.with_variant()
-    assert [func.variant for func in pipeline_sub_div.functions] == ["sub", "div"]
+    assert [func.variants for func in pipeline_sub_div.functions] == ["sub", "div"]
 
 
 def test_variant_pipeline_with_no_variant_group() -> None:
@@ -309,22 +314,22 @@ def test_variant_pipeline_with_no_variant_group() -> None:
 
 
 def test_variant_pipeline_copy_with_different_functions() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="d", variant_group="op2", variant="mul")
+    @pipefunc(output_name="d", variants={"mul": "op2"})
     def g(b, c):
         return b * c
 
     pipeline = VariantPipeline([f, g], default_variant={"op1": "add", "op2": "mul"})
 
     # Create new functions to replace the existing ones in the copy
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variant_group="op2", variant="div")
+    @pipefunc(output_name="d", variants={"div": "op2"})
     def g_alt(b, c):
         return b / c
 
@@ -346,19 +351,19 @@ def test_variant_pipeline_copy_with_different_functions() -> None:
 
 
 def test_variant_pipeline_copy_with_different_default_variant() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variant_group="op2", variant="mul")
+    @pipefunc(output_name="d", variants={"mul": "op2"})
     def g(b, c):
         return b * c
 
-    @pipefunc(output_name="d", variant_group="op2", variant="div")
+    @pipefunc(output_name="d", variants={"div": "op2"})
     def g_alt(b, c):
         return b / c
 
@@ -386,11 +391,11 @@ def test_variant_pipeline_copy_with_different_default_variant() -> None:
 
 
 def test_variant_pipeline_with_variant_as_input_to_another_function() -> None:
-    @pipefunc(output_name="c", variant_group="op", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op"})
     def f_alt(a, b):
         return a - b
 
@@ -439,11 +444,11 @@ def test_variant_pipeline_with_no_variants() -> None:
 
 
 def test_variant_pipeline_with_only_some_functions_having_variants() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
@@ -465,11 +470,11 @@ def test_variant_pipeline_with_only_some_functions_having_variants() -> None:
 
 
 def test_variant_pipeline_with_default_variant_not_in_functions() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
@@ -545,8 +550,8 @@ def test_from_pipelines_with_common_function_different_variant() -> None:
     )
     assert len(variant_pipeline.functions) == 3
     assert is_identical_pipefunc(variant_pipeline.functions[0], f)  # The common function f
-    assert variant_pipeline.functions[1].variant == "add_mul"
-    assert variant_pipeline.functions[2].variant == "add_div"
+    assert variant_pipeline.functions[1].variant == {"group1": "add_mul"}
+    assert variant_pipeline.functions[2].variant == {"group1": "add_div"}
 
 
 def test_exception_no_pipelines() -> None:

--- a/tests/test_variant_pipeline.py
+++ b/tests/test_variant_pipeline.py
@@ -5,7 +5,7 @@ import re
 
 import pytest
 
-from pipefunc import PipeFunc, Pipeline, VariantPipeline, pipefunc
+from pipefunc import Pipeline, VariantPipeline, pipefunc
 from pipefunc._variant_pipeline import is_identical_pipefunc
 
 has_psutil = importlib.util.find_spec("psutil") is not None
@@ -52,22 +52,22 @@ def test_variant_pipeline_single_group() -> None:
 
 def test_variant_pipeline_multiple_groups() -> None:
     # Define functions with variants and variant groups
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         print("Running f (add)")
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         print("Running f_alt (sub)")
         return a - b
 
-    @pipefunc(output_name="d", variants={"mul": "op2"})
+    @pipefunc(output_name="d", variants={"op2": "mul"})
     def g(b, c, x=3):
         print("Running g (mul)")
         return b * c * x
 
-    @pipefunc(output_name="d", variants={"div": "op2"})
+    @pipefunc(output_name="d", variants={"op2": "div"})
     def g_alt(b, c, x=3):
         print("Running g_alt (div)")
         return b * c / x
@@ -94,11 +94,11 @@ def test_lazy_debug_profile_cache() -> None:
     # We just check that these parameters are passed through to the Pipeline
     # No need to test the actual functionality of these parameters,
     # as they are tested in test_pipeline.py
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -124,11 +124,11 @@ def test_lazy_debug_profile_cache() -> None:
 
 
 def test_validate_type_annotations() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a: int, b: int) -> int:
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a: int, b: int) -> str:
         return str(a - b)
 
@@ -149,11 +149,11 @@ def test_validate_type_annotations() -> None:
 
 
 def test_error_handling_ambiguous_variant() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"add": "op2"})
+    @pipefunc(output_name="c", variants={"op2": "add"})
     def f_alt(a, b):
         return a - b
 
@@ -164,11 +164,11 @@ def test_error_handling_ambiguous_variant() -> None:
 
 
 def test_error_handling_with_variant() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -191,15 +191,15 @@ def test_error_handling_with_variant() -> None:
 
 
 def test_variants_mapping_and_inverse() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variants={"mul": "op2"})
+    @pipefunc(output_name="d", variants={"op2": "mul"})
     def g(b, c):
         return b * c
 
@@ -222,7 +222,7 @@ def test_variants_mapping_and_inverse() -> None:
 
 
 def test_copy_method() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
@@ -237,7 +237,7 @@ def test_copy_method() -> None:
 
 
 def test_getattr_for_pipeline_attributes() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
@@ -253,19 +253,19 @@ def test_getattr_for_pipeline_attributes() -> None:
 
 
 def test_default_variant() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variants={"mul": "op2"})
+    @pipefunc(output_name="d", variants={"op2": "mul"})
     def g(b, c):
         return b * c
 
-    @pipefunc(output_name="d", variants={"div": "op2"})
+    @pipefunc(output_name="d", variants={"op2": "div"})
     def g_alt(b, c):
         return b / c
 
@@ -273,10 +273,9 @@ def test_default_variant() -> None:
     pipeline = VariantPipeline([f, f_alt, g, g_alt], default_variant="add")
     pipeline_add = pipeline.with_variant()
     assert [func.variants for func in pipeline_add.functions] == [
-        {"add": "op1"},
-        {"sub": "op1"},
-        {"mul": "op2"},
-        {"div": "op2"},
+        {"op1": "add"},
+        {"op2": "mul"},
+        {"op2": "div"},
     ]
 
     # Test with a default variant per group
@@ -285,15 +284,18 @@ def test_default_variant() -> None:
         default_variant={"op1": "sub", "op2": "div"},
     )
     pipeline_sub_div = pipeline.with_variant()
-    assert [func.variants for func in pipeline_sub_div.functions] == ["sub", "div"]
+    assert [func.variants for func in pipeline_sub_div.functions] == [
+        {"op1": "sub"},
+        {"op2": "div"},
+    ]
 
 
 def test_variant_pipeline_with_no_variant_group() -> None:
-    @pipefunc(output_name="c", variant="add")
+    @pipefunc(output_name="c", variants="add")
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant="sub")
+    @pipefunc(output_name="c", variants="sub")
     def f_alt(a, b):
         return a - b
 
@@ -314,22 +316,22 @@ def test_variant_pipeline_with_no_variant_group() -> None:
 
 
 def test_variant_pipeline_copy_with_different_functions() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="d", variants={"mul": "op2"})
+    @pipefunc(output_name="d", variants={"op2": "mul"})
     def g(b, c):
         return b * c
 
     pipeline = VariantPipeline([f, g], default_variant={"op1": "add", "op2": "mul"})
 
     # Create new functions to replace the existing ones in the copy
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variants={"div": "op2"})
+    @pipefunc(output_name="d", variants={"op2": "div"})
     def g_alt(b, c):
         return b / c
 
@@ -351,19 +353,19 @@ def test_variant_pipeline_copy_with_different_functions() -> None:
 
 
 def test_variant_pipeline_copy_with_different_default_variant() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variants={"mul": "op2"})
+    @pipefunc(output_name="d", variants={"op2": "mul"})
     def g(b, c):
         return b * c
 
-    @pipefunc(output_name="d", variants={"div": "op2"})
+    @pipefunc(output_name="d", variants={"op2": "div"})
     def g_alt(b, c):
         return b / c
 
@@ -391,11 +393,11 @@ def test_variant_pipeline_copy_with_different_default_variant() -> None:
 
 
 def test_variant_pipeline_with_variant_as_input_to_another_function() -> None:
-    @pipefunc(output_name="c", variants={"add": "op"})
+    @pipefunc(output_name="c", variants={"op": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op"})
+    @pipefunc(output_name="c", variants={"op": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -416,17 +418,6 @@ def test_variant_pipeline_with_variant_as_input_to_another_function() -> None:
     assert pipeline_sub(a=1, b=2) == -2  # (1 - 2) * 2
 
 
-def test_pipefunc_with_variant_group_but_no_variant_error() -> None:
-    def f(a, b):
-        return a + b
-
-    with pytest.raises(
-        ValueError,
-        match="`variant_group='add'` cannot be set without a corresponding `variant`",
-    ):
-        PipeFunc(f, output_name="c", variant_group="add")
-
-
 def test_variant_pipeline_with_no_variants() -> None:
     @pipefunc(output_name="c")
     def f(a, b):
@@ -444,11 +435,11 @@ def test_variant_pipeline_with_no_variants() -> None:
 
 
 def test_variant_pipeline_with_only_some_functions_having_variants() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -470,11 +461,11 @@ def test_variant_pipeline_with_only_some_functions_having_variants() -> None:
 
 
 def test_variant_pipeline_with_default_variant_not_in_functions() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -550,8 +541,8 @@ def test_from_pipelines_with_common_function_different_variant() -> None:
     )
     assert len(variant_pipeline.functions) == 3
     assert is_identical_pipefunc(variant_pipeline.functions[0], f)  # The common function f
-    assert variant_pipeline.functions[1].variant == {"group1": "add_mul"}
-    assert variant_pipeline.functions[2].variant == {"group1": "add_div"}
+    assert variant_pipeline.functions[1].variants == {"group1": "add_mul"}
+    assert variant_pipeline.functions[2].variants == {"group1": "add_div"}
 
 
 def test_exception_no_pipelines() -> None:
@@ -580,8 +571,7 @@ def test_multi_dimensional_variants():
     def g_a(x, c):
         return x * c
 
-    # Test the string shorthand for variants
-    @pipefunc(output_name="y", variants="B")
+    @pipefunc(output_name="y", variants={"algorithm": "B"})
     def g_b(x, c):
         return x / c
 
@@ -593,7 +583,6 @@ def test_multi_dimensional_variants():
     assert variants == {
         "algorithm": {"A", "B"},
         "optimization": {"1", "2"},
-        None: {"B"},  # From the string shorthand
     }
 
     # Test selecting all dimensions

--- a/tests/test_variant_pipeline.py
+++ b/tests/test_variant_pipeline.py
@@ -722,7 +722,7 @@ def test_variant_selection_edge_cases() -> None:
 
 
 def test_variant_group_exception() -> None:
-    msg = "The `variant_group` parameter has been removed. Use the `variant = {'group1': 'add'}` parameter instead"
+    msg = "The `variant_group` parameter has been removed in v0.58.0. Use the `variant = {'group1': 'add'}` parameter instead"
     with pytest.raises(ValueError, match=msg):
 
         @pipefunc(output_name="c", variant="add", variant_group="group1")

--- a/tests/test_variant_pipeline.py
+++ b/tests/test_variant_pipeline.py
@@ -13,12 +13,12 @@ has_psutil = importlib.util.find_spec("psutil") is not None
 
 def test_variant_pipeline_single_group() -> None:
     # Define functions with variants and variant groups
-    @pipefunc(output_name="c", variants="add")
+    @pipefunc(output_name="c", variant="add")
     def f(a, b):
         print("Running f (add)")
         return a + b
 
-    @pipefunc(output_name="c", variants="sub")
+    @pipefunc(output_name="c", variant="sub")
     def f_alt(a, b):
         print("Running f_alt (sub)")
         return a - b
@@ -52,22 +52,22 @@ def test_variant_pipeline_single_group() -> None:
 
 def test_variant_pipeline_multiple_groups() -> None:
     # Define functions with variants and variant groups
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         print("Running f (add)")
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         print("Running f_alt (sub)")
         return a - b
 
-    @pipefunc(output_name="d", variants={"op2": "mul"})
+    @pipefunc(output_name="d", variant={"op2": "mul"})
     def g(b, c, x=3):
         print("Running g (mul)")
         return b * c * x
 
-    @pipefunc(output_name="d", variants={"op2": "div"})
+    @pipefunc(output_name="d", variant={"op2": "div"})
     def g_alt(b, c, x=3):
         print("Running g_alt (div)")
         return b * c / x
@@ -94,11 +94,11 @@ def test_lazy_debug_profile_cache() -> None:
     # We just check that these parameters are passed through to the Pipeline
     # No need to test the actual functionality of these parameters,
     # as they are tested in test_pipeline.py
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -124,11 +124,11 @@ def test_lazy_debug_profile_cache() -> None:
 
 
 def test_validate_type_annotations() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a: int, b: int) -> int:
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a: int, b: int) -> str:
         return str(a - b)
 
@@ -149,11 +149,11 @@ def test_validate_type_annotations() -> None:
 
 
 def test_error_handling_ambiguous_variant() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op2": "add"})
+    @pipefunc(output_name="c", variant={"op2": "add"})
     def f_alt(a, b):
         return a - b
 
@@ -164,11 +164,11 @@ def test_error_handling_ambiguous_variant() -> None:
 
 
 def test_error_handling_with_variant() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -191,15 +191,15 @@ def test_error_handling_with_variant() -> None:
 
 
 def test_variants_mapping_and_inverse() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variants={"op2": "mul"})
+    @pipefunc(output_name="d", variant={"op2": "mul"})
     def g(b, c):
         return b * c
 
@@ -222,7 +222,7 @@ def test_variants_mapping_and_inverse() -> None:
 
 
 def test_copy_method() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
@@ -237,7 +237,7 @@ def test_copy_method() -> None:
 
 
 def test_getattr_for_pipeline_attributes() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
@@ -253,26 +253,26 @@ def test_getattr_for_pipeline_attributes() -> None:
 
 
 def test_default_variant() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variants={"op2": "mul"})
+    @pipefunc(output_name="d", variant={"op2": "mul"})
     def g(b, c):
         return b * c
 
-    @pipefunc(output_name="d", variants={"op2": "div"})
+    @pipefunc(output_name="d", variant={"op2": "div"})
     def g_alt(b, c):
         return b / c
 
     # Test with a single default variant
     pipeline = VariantPipeline([f, f_alt, g, g_alt], default_variant="add")
     pipeline_add = pipeline.with_variant()
-    assert [func.variants for func in pipeline_add.functions] == [
+    assert [func.variant for func in pipeline_add.functions] == [
         {"op1": "add"},
         {"op2": "mul"},
         {"op2": "div"},
@@ -284,18 +284,18 @@ def test_default_variant() -> None:
         default_variant={"op1": "sub", "op2": "div"},
     )
     pipeline_sub_div = pipeline.with_variant()
-    assert [func.variants for func in pipeline_sub_div.functions] == [
+    assert [func.variant for func in pipeline_sub_div.functions] == [
         {"op1": "sub"},
         {"op2": "div"},
     ]
 
 
 def test_variant_pipeline_with_no_variant_group() -> None:
-    @pipefunc(output_name="c", variants="add")
+    @pipefunc(output_name="c", variant="add")
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants="sub")
+    @pipefunc(output_name="c", variant="sub")
     def f_alt(a, b):
         return a - b
 
@@ -316,22 +316,22 @@ def test_variant_pipeline_with_no_variant_group() -> None:
 
 
 def test_variant_pipeline_copy_with_different_functions() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="d", variants={"op2": "mul"})
+    @pipefunc(output_name="d", variant={"op2": "mul"})
     def g(b, c):
         return b * c
 
     pipeline = VariantPipeline([f, g], default_variant={"op1": "add", "op2": "mul"})
 
     # Create new functions to replace the existing ones in the copy
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variants={"op2": "div"})
+    @pipefunc(output_name="d", variant={"op2": "div"})
     def g_alt(b, c):
         return b / c
 
@@ -353,19 +353,19 @@ def test_variant_pipeline_copy_with_different_functions() -> None:
 
 
 def test_variant_pipeline_copy_with_different_default_variant() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
-    @pipefunc(output_name="d", variants={"op2": "mul"})
+    @pipefunc(output_name="d", variant={"op2": "mul"})
     def g(b, c):
         return b * c
 
-    @pipefunc(output_name="d", variants={"op2": "div"})
+    @pipefunc(output_name="d", variant={"op2": "div"})
     def g_alt(b, c):
         return b / c
 
@@ -393,11 +393,11 @@ def test_variant_pipeline_copy_with_different_default_variant() -> None:
 
 
 def test_variant_pipeline_with_variant_as_input_to_another_function() -> None:
-    @pipefunc(output_name="c", variants={"op": "add"})
+    @pipefunc(output_name="c", variant={"op": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op": "sub"})
+    @pipefunc(output_name="c", variant={"op": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -435,11 +435,11 @@ def test_variant_pipeline_with_no_variants() -> None:
 
 
 def test_variant_pipeline_with_only_some_functions_having_variants() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -461,11 +461,11 @@ def test_variant_pipeline_with_only_some_functions_having_variants() -> None:
 
 
 def test_variant_pipeline_with_default_variant_not_in_functions() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -541,8 +541,8 @@ def test_from_pipelines_with_common_function_different_variant() -> None:
     )
     assert len(variant_pipeline.functions) == 3
     assert is_identical_pipefunc(variant_pipeline.functions[0], f)  # The common function f
-    assert variant_pipeline.functions[1].variants == {"group1": "add_mul"}
-    assert variant_pipeline.functions[2].variants == {"group1": "add_div"}
+    assert variant_pipeline.functions[1].variant == {"group1": "add_mul"}
+    assert variant_pipeline.functions[2].variant == {"group1": "add_div"}
 
 
 def test_exception_no_pipelines() -> None:
@@ -551,27 +551,27 @@ def test_exception_no_pipelines() -> None:
 
 
 def test_multi_dimensional_variants():
-    @pipefunc(output_name="x", variants={"algorithm": "A", "optimization": "1"})
+    @pipefunc(output_name="x", variant={"algorithm": "A", "optimization": "1"})
     def f_a1(a, b):
         return a + b
 
-    @pipefunc(output_name="x", variants={"algorithm": "A", "optimization": "2"})
+    @pipefunc(output_name="x", variant={"algorithm": "A", "optimization": "2"})
     def f_a2(a, b):
         return a + b + 1
 
-    @pipefunc(output_name="x", variants={"algorithm": "B", "optimization": "1"})
+    @pipefunc(output_name="x", variant={"algorithm": "B", "optimization": "1"})
     def f_b1(a, b):
         return a - b
 
-    @pipefunc(output_name="x", variants={"algorithm": "B", "optimization": "2"})
+    @pipefunc(output_name="x", variant={"algorithm": "B", "optimization": "2"})
     def f_b2(a, b):
         return a - b + 1
 
-    @pipefunc(output_name="y", variants={"algorithm": "A"})
+    @pipefunc(output_name="y", variant={"algorithm": "A"})
     def g_a(x, c):
         return x * c
 
-    @pipefunc(output_name="y", variants={"algorithm": "B"})
+    @pipefunc(output_name="y", variant={"algorithm": "B"})
     def g_b(x, c):
         return x / c
 

--- a/tests/test_variant_pipeline.py
+++ b/tests/test_variant_pipeline.py
@@ -719,3 +719,18 @@ def test_variant_selection_edge_cases() -> None:
     result = pipeline.with_variant(select={"method": "sub", "version": "v1"})
     assert isinstance(result, Pipeline)
     assert result(a=2, b=3) == -1  # (2-3) = -1
+
+
+def test_variant_group_exception() -> None:
+    msg = "The `variant_group` parameter has been removed. Use the `variant = {'group1': 'add'}` parameter instead"
+    with pytest.raises(ValueError, match=msg):
+
+        @pipefunc(output_name="c", variant="add", variant_group="group1")
+        def f1(a, b):
+            return a + b
+
+    def f2(a, b):
+        return a + b
+
+    with pytest.raises(ValueError, match=msg):
+        PipeFunc(f2, output_name="c", variant="add", variant_group="group1")

--- a/tests/test_variant_pipeline_widgets.py
+++ b/tests/test_variant_pipeline_widgets.py
@@ -27,11 +27,11 @@ def patched_show():
 
 @pytest.mark.skipif(not has_graphviz, reason="requires graphviz")
 def test_visualize_default_backend() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -46,11 +46,11 @@ def test_visualize_default_backend() -> None:
 
 @pytest.mark.skipif(not has_graphviz, reason="requires graphviz")
 def test_visualize_graphviz_backend() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -64,11 +64,11 @@ def test_visualize_graphviz_backend() -> None:
     reason="requires ipywidgets and graphviz",
 )
 def test_visualize_graphviz_widget_backend() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -79,11 +79,11 @@ def test_visualize_graphviz_widget_backend() -> None:
 
 @pytest.mark.skipif(not has_matplotlib, reason="requires matplotlib")
 def test_visualize_matplotlib_backend() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -98,11 +98,11 @@ def test_visualize_matplotlib_backend() -> None:
     reason="requires ipywidgets and graphviz",
 )
 def test_visualize_with_variant_selection() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"sub": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -113,7 +113,7 @@ def test_visualize_with_variant_selection() -> None:
 
 @pytest.mark.skipif(not has_ipywidgets or not has_rich, reason="requires ipywidgets and rich")
 def test_repr_mimebundle_with_ipywidgets_and_rich() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 
@@ -123,7 +123,7 @@ def test_repr_mimebundle_with_ipywidgets_and_rich() -> None:
 
 
 def test_repr_mimebundle_without_ipywidgets_or_rich() -> None:
-    @pipefunc(output_name="c", variants={"add": "op1"})
+    @pipefunc(output_name="c", variants={"op1": "add"})
     def f(a, b):
         return a + b
 

--- a/tests/test_variant_pipeline_widgets.py
+++ b/tests/test_variant_pipeline_widgets.py
@@ -27,11 +27,11 @@ def patched_show():
 
 @pytest.mark.skipif(not has_graphviz, reason="requires graphviz")
 def test_visualize_default_backend() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
@@ -46,11 +46,11 @@ def test_visualize_default_backend() -> None:
 
 @pytest.mark.skipif(not has_graphviz, reason="requires graphviz")
 def test_visualize_graphviz_backend() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
@@ -64,11 +64,11 @@ def test_visualize_graphviz_backend() -> None:
     reason="requires ipywidgets and graphviz",
 )
 def test_visualize_graphviz_widget_backend() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
@@ -79,11 +79,11 @@ def test_visualize_graphviz_widget_backend() -> None:
 
 @pytest.mark.skipif(not has_matplotlib, reason="requires matplotlib")
 def test_visualize_matplotlib_backend() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
@@ -98,11 +98,11 @@ def test_visualize_matplotlib_backend() -> None:
     reason="requires ipywidgets and graphviz",
 )
 def test_visualize_with_variant_selection() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variant_group="op1", variant="sub")
+    @pipefunc(output_name="c", variants={"sub": "op1"})
     def f_alt(a, b):
         return a - b
 
@@ -113,7 +113,7 @@ def test_visualize_with_variant_selection() -> None:
 
 @pytest.mark.skipif(not has_ipywidgets or not has_rich, reason="requires ipywidgets and rich")
 def test_repr_mimebundle_with_ipywidgets_and_rich() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 
@@ -123,7 +123,7 @@ def test_repr_mimebundle_with_ipywidgets_and_rich() -> None:
 
 
 def test_repr_mimebundle_without_ipywidgets_or_rich() -> None:
-    @pipefunc(output_name="c", variant_group="op1", variant="add")
+    @pipefunc(output_name="c", variants={"add": "op1"})
     def f(a, b):
         return a + b
 

--- a/tests/test_variant_pipeline_widgets.py
+++ b/tests/test_variant_pipeline_widgets.py
@@ -27,11 +27,11 @@ def patched_show():
 
 @pytest.mark.skipif(not has_graphviz, reason="requires graphviz")
 def test_visualize_default_backend() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -46,11 +46,11 @@ def test_visualize_default_backend() -> None:
 
 @pytest.mark.skipif(not has_graphviz, reason="requires graphviz")
 def test_visualize_graphviz_backend() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -64,11 +64,11 @@ def test_visualize_graphviz_backend() -> None:
     reason="requires ipywidgets and graphviz",
 )
 def test_visualize_graphviz_widget_backend() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -79,11 +79,11 @@ def test_visualize_graphviz_widget_backend() -> None:
 
 @pytest.mark.skipif(not has_matplotlib, reason="requires matplotlib")
 def test_visualize_matplotlib_backend() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -98,11 +98,11 @@ def test_visualize_matplotlib_backend() -> None:
     reason="requires ipywidgets and graphviz",
 )
 def test_visualize_with_variant_selection() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
-    @pipefunc(output_name="c", variants={"op1": "sub"})
+    @pipefunc(output_name="c", variant={"op1": "sub"})
     def f_alt(a, b):
         return a - b
 
@@ -113,7 +113,7 @@ def test_visualize_with_variant_selection() -> None:
 
 @pytest.mark.skipif(not has_ipywidgets or not has_rich, reason="requires ipywidgets and rich")
 def test_repr_mimebundle_with_ipywidgets_and_rich() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 
@@ -123,7 +123,7 @@ def test_repr_mimebundle_with_ipywidgets_and_rich() -> None:
 
 
 def test_repr_mimebundle_without_ipywidgets_or_rich() -> None:
-    @pipefunc(output_name="c", variants={"op1": "add"})
+    @pipefunc(output_name="c", variant={"op1": "add"})
     def f(a, b):
         return a + b
 


### PR DESCRIPTION
This change allows multiple variant_groups per single `pipefunc`. Now `variant` can be a dict like `{"algorithm": "fast", "optimization": "level1"}`.

This means that the `variant_group` parameter is now deprecated because the information is in `variant` itself.