### PR TITLE
TST: Speedup tests

### DIFF
--- a/tests/map/test_adaptive.py
+++ b/tests/map/test_adaptive.py
@@ -519,6 +519,7 @@ def test_adaptive_run_dynamic_internal_shape():
         inputs={},
         adaptive_dimensions={"a": (0.0, 1.0)},
         adaptive_output="sum",
+        map_kwargs={"parallel": False, "storage": "dict"},
     )
 
     adaptive.runner.simple(learner, npoints_goal=10)

--- a/tests/map/test_eager_scheduler.py
+++ b/tests/map/test_eager_scheduler.py
@@ -341,6 +341,8 @@ def test_eager_scheduler_with_fixed_indices(tmp_path: Path):
         run_folder=run_folder,
         fixed_indices={"i": 2},
         show_progress=False,
+        parallel=False,
+        storage="dict",
     )
 
     # Result should be a 1D array with only the processed value at index 2
@@ -360,6 +362,8 @@ def test_eager_scheduler_with_fixed_indices(tmp_path: Path):
         fixed_indices={"i": 3},
         cleanup=False,  # Don't clean up to keep previous results
         show_progress=False,
+        parallel=False,
+        storage="dict",
     )
 
     # Now both indices 2 and 3 should be processed
@@ -507,6 +511,7 @@ def test_eager_scheduler_with_different_storage(tmp_path: Path, storage: str):
         run_folder=run_folder,
         storage=storage,
         show_progress=False,
+        parallel=False,
     )
 
     assert result["e"].output == "e(c(a),d(b))"

--- a/tests/map/test_eager_scheduler.py
+++ b/tests/map/test_eager_scheduler.py
@@ -1,6 +1,6 @@
 import threading
 import time
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import numpy as np
@@ -114,6 +114,8 @@ def test_complex_dependency_graph(tmp_path: Path):
         inputs={},
         run_folder=run_folder,
         show_progress=False,
+        parallel=False,
+        storage="dict",
     )
 
     assert result["e"].output == "e(c(a),d(b))"
@@ -205,7 +207,7 @@ def test_eager_scheduler_with_custom_executor(tmp_path: Path):
     pipeline = Pipeline([task_a, task_b, task_c, task_d, task_e])
     run_folder = tmp_path / "custom_executor"
 
-    with ProcessPoolExecutor(max_workers=2) as executor:
+    with ThreadPoolExecutor(max_workers=2) as executor:
         result = pipeline.map(
             scheduling_strategy="eager",
             inputs={},
@@ -229,6 +231,8 @@ def test_eager_scheduler_without_returning_results(tmp_path: Path):
         run_folder=run_folder,
         return_results=False,
         show_progress=False,
+        parallel=False,
+        storage="dict",
     )
 
     # Result should be an empty dict
@@ -567,6 +571,7 @@ def test_eager_scheduler_with_persist_memory(
         storage="dict",  # Memory-based storage
         persist_memory=persist_memory,
         show_progress=False,
+        parallel=False,
     )
 
     assert result["a"].output == "a"

--- a/tests/map/test_eager_scheduler.py
+++ b/tests/map/test_eager_scheduler.py
@@ -608,6 +608,8 @@ def test_eager_scheduler_with_complex_mapspec(tmp_path: Path):
         inputs=inputs,
         run_folder=run_folder,
         show_progress=False,
+        storage="dict",
+        parallel=False,
     )
 
     assert result["matrix"].output.tolist() == [[4, 5], [8, 10], [12, 15]]

--- a/tests/map/test_eager_scheduler.py
+++ b/tests/map/test_eager_scheduler.py
@@ -147,6 +147,8 @@ def test_eager_scheduler_with_mapspec(tmp_path: Path):
         inputs=inputs,
         run_folder=run_folder,
         show_progress=False,
+        storage="dict",
+        parallel=False,
     )
 
     assert result["sum"].output == 30  # 2 + 4 + 6 + 8 + 10 = 30
@@ -315,6 +317,8 @@ def test_eager_scheduler_with_internal_shapes(tmp_path: Path):
         inputs={},
         run_folder=run_folder,
         show_progress=False,
+        parallel=False,
+        storage="dict",
     )
 
     assert result["sum"].output == 20  # (1+2+3+4)*2 = 20
@@ -491,6 +495,8 @@ def test_eager_scheduler_with_chunksizes(tmp_path: Path):
         run_folder=run_folder,
         chunksizes=5,  # Process in chunks of 5
         show_progress=False,
+        parallel=False,
+        storage="dict",
     )
 
     # Check results

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -878,7 +878,7 @@ def test_from_step_2_dim_array_2(storage: str, tmp_path: Path) -> None:
     xarray_dataset_from_results(inputs, results, pipeline)
 
 
-def test_add_mapspec_axis_from_step(storage: str, tmp_path: Path) -> None:
+def test_add_mapspec_axis_from_step(tmp_path: Path) -> None:
     @pipefunc(output_name="x")
     def generate_ints(n: int) -> list[int]:
         return list(range(n))
@@ -915,7 +915,7 @@ def test_add_mapspec_axis_from_step(storage: str, tmp_path: Path) -> None:
         tmp_path,
         internal_shapes=internal_shapes,  # type: ignore[arg-type]
         parallel=False,
-        storage=storage,
+        storage="dict",
     )
     assert results["sum"].output == 13
 
@@ -938,7 +938,7 @@ def test_add_mapspec_axis_from_step(storage: str, tmp_path: Path) -> None:
         tmp_path,
         internal_shapes=internal_shapes_map,  # type: ignore[arg-type]
         parallel=False,
-        storage=storage,
+        storage="dict",
     )
     assert results["sum"].output.tolist() == [13]
 

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -1699,7 +1699,13 @@ def test_pipeline_with_heterogeneous_chunksize(chunksizes):
         ValueError,
         match=re.escape("Invalid chunksize -1 for z"),
     ):
-        pipeline.map(inputs, chunksizes={"z": -1}, parallel=False, storage="dict")
+        pipeline.map(
+            inputs,
+            chunksizes={"z": -1},
+            parallel=True,
+            storage="dict",
+            executor=ThreadPoolExecutor(),
+        )
 
 
 def test_map_range():

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -1684,7 +1684,13 @@ def test_pipeline_with_heterogeneous_chunksize(chunksizes):
 
     pipeline = Pipeline([f, g, h])
     inputs = {"x": [1, 2, 3]}
-    results = pipeline.map(inputs, chunksizes=chunksizes, parallel=False, storage="dict")
+    results = pipeline.map(
+        inputs,
+        chunksizes=chunksizes,
+        parallel=True,
+        storage="dict",
+        executor=ThreadPoolExecutor(),
+    )
     assert results["y1"].output.tolist() == [0, 1, 2]
     assert results["z"].output.tolist() == [2, 3, 4]
     assert results["y2"].output.tolist() == [2, 3, 4]

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -1547,6 +1547,7 @@ async def test_map_async_with_progress(scheduling_strategy: Literal["generation"
         {"x": [1, 2, 3]},
         show_progress=True,
         scheduling_strategy=scheduling_strategy,
+        executor=ThreadPoolExecutor(),
     )
     # Test that the progress tracker is working
     progress = async_map.progress

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -955,7 +955,7 @@ def test_add_mapspec_axis_from_step(tmp_path: Path) -> None:
         tmp_path,
         internal_shapes=internal_shapes_map,  # type: ignore[arg-type]
         parallel=False,
-        storage=storage,
+        storage="dict",
     )
     assert results["sum"].output.tolist() == [13]
     load_xarray_dataset(run_folder=tmp_path)
@@ -1683,7 +1683,7 @@ def test_pipeline_with_heterogeneous_chunksize(chunksizes):
 
     pipeline = Pipeline([f, g, h])
     inputs = {"x": [1, 2, 3]}
-    results = pipeline.map(inputs, chunksizes=chunksizes)
+    results = pipeline.map(inputs, chunksizes=chunksizes, parallel=False, storage="dict")
     assert results["y1"].output.tolist() == [0, 1, 2]
     assert results["z"].output.tolist() == [2, 3, 4]
     assert results["y2"].output.tolist() == [2, 3, 4]
@@ -1803,11 +1803,11 @@ def test_profiling_and_parallel_unsupported_warning() -> None:
 
     test_pipeline_with_profile_true = Pipeline([a], profile=True)
     with pytest.warns(UserWarning, match="`profile=True` is not supported with `parallel=True`"):
-        test_pipeline_with_profile_true.map({"val": np.array([1, 2, 3])})
+        test_pipeline_with_profile_true.map({"val": [1]})
 
     test_pipeline_with_profile_none = Pipeline([a_profile], profile=None)
     with pytest.warns(UserWarning, match="`profile=True` is not supported with `parallel=True`"):
-        test_pipeline_with_profile_none.map({"val": np.array([1, 2, 3])})
+        test_pipeline_with_profile_none.map({"val": [1]})
 
 
 def test_map_with_auto_subpipeline(tmp_path: Path):

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -1693,7 +1693,7 @@ def test_pipeline_with_heterogeneous_chunksize(chunksizes):
         ValueError,
         match=re.escape("Invalid chunksize -1 for z"),
     ):
-        pipeline.map(inputs, chunksizes={"z": -1})
+        pipeline.map(inputs, chunksizes={"z": -1}, parallel=False, storage="dict")
 
 
 def test_map_range():
@@ -1703,7 +1703,7 @@ def test_map_range():
 
     pipeline = Pipeline([f])
     inputs = {"x": range(3)}
-    r = pipeline.map(inputs, parallel=False)
+    r = pipeline.map(inputs, parallel=False, storage="dict")
     assert r["y"].output.tolist() == [0, 1, 2]
     if has_xarray:
         ds = xarray_dataset_from_results(inputs, r, pipeline)

--- a/tests/map/test_run_dynamic_internal_shape.py
+++ b/tests/map/test_run_dynamic_internal_shape.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import random
 import re
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
@@ -87,7 +88,13 @@ async def test_dynamic_internal_shape_async(
 ) -> None:
     pipeline = _pipeline(dim)
     assert pipeline.mapspecs_as_strings == ["... -> x[i]", "x[i] -> y[i]"]
-    runner = pipeline.map_async({}, run_folder=tmp_path, return_results=return_results)
+    runner = pipeline.map_async(
+        {},
+        run_folder=tmp_path,
+        return_results=return_results,
+        executor=ThreadPoolExecutor(),
+        storage="dict",
+    )
     results = await runner.task
     expected_sum = 12
     expected_y = [0, 2, 4, 6]

--- a/tests/map/test_run_dynamic_internal_shape.py
+++ b/tests/map/test_run_dynamic_internal_shape.py
@@ -520,7 +520,7 @@ def test_simple_2d(
 
 @pytest.mark.parametrize("return_results", [True, False])
 @pytest.mark.parametrize("parallel", [True, False])
-@pytest.mark.parametrize("storage", ["file_array", "dict", "shared_memory_dict"])
+@pytest.mark.parametrize("storage", ["file_array", "dict"])
 def test_multiple_outputs_with_dynamic_shape_and_individual_outputs_are_nd_arrays(
     tmp_path: Path,
     return_results: bool,  # noqa: FBT001

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -748,7 +748,7 @@ def test_parameterless_pipefunc() -> None:
     assert pipeline() == 1
     assert pipeline.topological_generations.root_args == []
     assert pipeline.topological_generations.function_lists == [[pipeline["c"]]]
-    r = pipeline.map({})
+    r = pipeline.map({}, storage="dict", parallel=False)
     assert r["c"].output == 1
 
     @pipefunc(output_name="d")
@@ -767,7 +767,7 @@ def test_parameterless_pipefunc() -> None:
         [pipeline["c"], pipeline["d"]],
         [pipeline["e"]],
     ]
-    r = pipeline.map({})
+    r = pipeline.map({}, storage="dict", parallel=False)
     assert r["e"].output == 3
 
 
@@ -1008,7 +1008,7 @@ def test_nested_pipefunc_in_pipeline_renames() -> None:
     assert func.pipeline.functions[0].renames == {}
     r = pipeline.run("test.y", kwargs={"test.n": 2})
     assert r == 8
-    r = pipeline.map(inputs={"test.n": 2})
+    r = pipeline.map(inputs={"test.n": 2}, storage="dict", parallel=False)
     assert r["test.y"].output == 8
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -886,7 +886,7 @@ def test_double_output_then_iterate_over_single_axis():
             PipeFunc(f2, "c", mapspec="a[:, j] -> c[j]"),
         ],
     )
-    pipeline.map({"x": np.arange(3), "y": np.arange(3)})
+    pipeline.map({"x": np.arange(3), "y": np.arange(3)}, parallel=False, storage="dict")
     assert pipeline.mapspec_axes == {
         "a": ("i", "j"),
         "b": ("i", "j"),

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -951,12 +951,16 @@ def test_pipeline_map_zero_size() -> None:
     result = pipeline.map(
         {"mock_complete": [0], "mock_incomplete": [1, 2, 3]},
         internal_shapes={"incomplete": ("?",)},
+        parallel=False,
+        storage="dict",
     )
     assert result["result"].output == [0, 1, 2, 3]
     # Now with empty complete
     result = pipeline.map(
         {"mock_complete": [], "mock_incomplete": [0, 1, 2, 3]},
         internal_shapes={"incomplete": ("?",)},
+        parallel=False,
+        storage="dict",
     )
     assert result["result"].output == [0, 1, 2, 3]
 
@@ -965,6 +969,8 @@ def test_pipeline_map_zero_size() -> None:
     result = pipeline.map(
         {"mock_complete": [0, 1, 2, 3], "mock_incomplete": []},
         internal_shapes={"incomplete": ("?",)},
+        parallel=False,
+        storage="dict",
     )
     assert result["result"].output == [0, 1, 2, 3]
 

--- a/tests/test_pipeline_mapspec.py
+++ b/tests/test_pipeline_mapspec.py
@@ -415,5 +415,5 @@ def test_zero_sizes_list_with_progress_bar(show_progress: bool) -> None:  # noqa
         return 2 * x
 
     pipeline_sum = Pipeline([generate_ints, double_it])
-    results = pipeline_sum.map({}, show_progress=show_progress)
+    results = pipeline_sum.map({}, show_progress=show_progress, parallel=False, storage="dict")
     assert results["y"].output.tolist() == []

--- a/tests/test_pipeline_mapspec.py
+++ b/tests/test_pipeline_mapspec.py
@@ -342,6 +342,8 @@ def test_calling_add_with_autogen_mapspec(dim: int | Literal["?"]):
     results = pipeline.map(
         inputs={"vector": [1, 2, 3], "factor": [1, 2, 3]},
         internal_shapes={"foo_out": (dim,)},
+        storage="dict",
+        parallel=False,
     )
     assert results["bar_out"].output.tolist() == [1, 4, 9]
 

--- a/tests/test_pipeline_update.py
+++ b/tests/test_pipeline_update.py
@@ -232,7 +232,7 @@ def test_scope_with_mapspec() -> None:
     assert str(f.mapspec) == "foo.a[i] -> foo.c[i]"
     pipeline = Pipeline([f])
     assert pipeline.mapspecs_as_strings == ["foo.a[i] -> foo.c[i]"]
-    results = pipeline.map({"foo": {"a": [0, 1, 2]}, "b": 1})
+    results = pipeline.map({"foo": {"a": [0, 1, 2]}, "b": 1}, storage="dict", parallel=False)
     assert results["foo.c"].output.tolist() == [1, 2, 3]
 
 


### PR DESCRIPTION
Currently there are a lot of slow tests:
```bash
33.87s call     tests/map/test_adaptive.py::test_adaptive_run_dynamic_internal_shape
15.87s call     tests/map/test_map.py::test_add_mapspec_axis_from_step[shared_memory_dict]
11.56s call     tests/map/test_map.py::test_add_mapspec_axis_from_step[zarr_shared_memory]
11.31s call     tests/map/test_run_dynamic_internal_shape.py::test_multiple_outputs_with_dynamic_shape_and_individual_outputs_are_nd_arrays[shared_memory_dict-True-True]
8.68s call     tests/test_pipeline.py::test_pipeline_map_zero_size
8.05s call     tests/map/test_run_dynamic_internal_shape.py::test_multiple_outputs_with_dynamic_shape_and_individual_outputs_are_nd_arrays[shared_memory_dict-True-False]
6.87s call     tests/map/test_map.py::test_profiling_and_parallel_unsupported_warning
6.83s call     tests/map/test_map.py::test_parallel_memory_storage[zarr_memory]
6.13s call     tests/map/test_map.py::test_parallel_memory_storage[dict]
4.99s call     tests/map/test_map.py::test_pipeline_with_heterogeneous_executor
4.87s call     tests/map/test_map.py::test_pipeline_with_heterogeneous_chunksize[chunksizes0]
4.56s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_fixed_indices
4.25s call     tests/map/test_map.py::test_map_async_with_progress[eager]
4.23s call     tests/map/test_map.py::test_map_async_with_progress[generation]
4.21s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_complex_mapspec
4.13s call     tests/map/test_run_dynamic_internal_shape.py::test_dynamic_internal_shape_async[None-False]
4.06s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_without_returning_results
4.05s call     tests/test_pipeline.py::test_double_output_then_iterate_over_single_axis
4.00s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_internal_shapes
4.00s call     tests/map/test_run_dynamic_internal_shape.py::test_dynamic_internal_shape_async[?-False]
3.95s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_persist_memory[True]
3.91s call     tests/map/test_map.py::test_pipeline_with_heterogeneous_chunksize[1]
3.78s call     tests/test_pipeline_mapspec.py::test_mapping_over_default
3.75s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_mapspec
3.75s call     tests/map/test_run_dynamic_internal_shape.py::test_dynamic_internal_shape_async[None-True]
3.75s call     tests/map/test_run_dynamic_internal_shape.py::test_dynamic_internal_shape_async[?-True]
3.66s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_different_storage[shared_memory_dict]
3.64s call     tests/test_pipeline.py::test_parameterless_pipefunc
3.62s call     tests/map/test_eager_scheduler.py::test_complex_dependency_graph
3.41s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_custom_executor
3.29s call     tests/test_pipeline_mapspec.py::test_calling_add_with_autogen_mapspec[3]
3.10s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_different_storage[dict]
3.05s call     tests/map/test_run_dynamic_internal_shape.py::test_multiple_outputs_with_dynamic_shape_and_individual_outputs_are_nd_arrays[shared_memory_dict-False-True]
2.85s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_persist_memory[False]
2.80s call     tests/map/test_map.py::test_parallel
2.74s call     tests/test_cache.py::test_pickling_and_deepcopy_lru[True]
2.74s call     tests/test_plotting.py::test_plot_with_defaults[holoviews]
2.71s call     tests/test_pipeline_update.py::test_scope_with_mapspec
2.66s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_diamond_pattern
2.48s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_chunksizes
```

After 
```bash
6.50s call     tests/map/test_map.py::test_parallel_memory_storage[zarr_memory]
5.98s call     tests/map/test_map.py::test_profiling_and_parallel_unsupported_warning
5.55s call     tests/map/test_map.py::test_parallel_memory_storage[dict]
4.56s call     tests/map/test_map.py::test_parallel
3.37s call     tests/test_pipeline_mapspec.py::test_mapping_over_default
3.14s call     tests/map/test_run_dynamic_internal_shape.py::test_multiple_outputs_with_dynamic_shape_and_individual_outputs_are_nd_arrays[dict-True-False]
3.11s call     tests/map/test_run_dynamic_internal_shape.py::test_multiple_outputs_with_dynamic_shape_and_individual_outputs_are_nd_arrays[dict-True-True]
2.97s call     tests/test_pipeline_mapspec.py::test_with_progress
2.78s call     tests/map/test_eager_scheduler.py::test_eager_scheduler_with_diamond_pattern
2.66s call     tests/map/test_map.py::test_storage_options_zarr_memory_parallel
2.52s call     tests/map/test_run_dynamic_internal_shape.py::test_multiple_outputs_with_dynamic_shape_and_individual_outputs_are_nd_arrays[file_array-True-False]
2.51s call     tests/map/test_map.py::test_pipeline_with_heterogeneous_chunksize[1]
2.45s setup    tests/test_variant_pipeline_widgets.py::test_visualize_default_backend
2.42s call     tests/map/test_map.py::test_map_with_partial
2.39s setup    tests/test_variant_pipeline_widgets.py::test_visualize_with_variant_selection
2.37s setup    tests/test_variant_pipeline_widgets.py::test_repr_mimebundle_without_ipywidgets_or_rich
```