### PR TITLE
BUG: Display mapspec index in grouped Graphviz nodes

### DIFF
--- a/pipefunc/_plotting.py
+++ b/pipefunc/_plotting.py
@@ -403,6 +403,7 @@ def visualize_graphviz(  # noqa: PLR0912, C901, PLR0915
     hints = _all_type_annotations(graph)
     nodes = _Nodes.from_graph(plot_graph)
     labels = _Labels.from_graph(plot_graph)
+    arg_mapspec_before_grouping = _Labels.from_graph(graph).arg_mapspec
 
     # Define a mapping for node configurations
     node_types: dict[str, tuple[list, dict]] = {
@@ -472,7 +473,7 @@ def visualize_graphviz(  # noqa: PLR0912, C901, PLR0915
                 node,
                 hints,
                 defaults,
-                labels.arg_mapspec,
+                arg_mapspec_before_grouping,
                 include_full_mapspec,
             )
             attribs = dict(node_defaults, label=f"<{label}>", **config)


### PR DESCRIPTION
The 'arg_mapspec' used for generating node labels was calculated after the 'create_grouped_parameter_graph' function modified the graph. This function removes the original argument nodes when grouping, causing the mapspec information (like '[i]') to be lost for those arguments.

This commit calculates the 'arg_mapspec' from the original graph *before* grouping is applied and passes this pre-calculated map to the '_generate_node_label' function. This ensures that the mapspec index is correctly displayed in the labels of grouped argument nodes.