### PR TITLE
ENH: Add support for additional Executor classes 

### DIFF
--- a/docs/source/concepts/execution-and-parallelism.md
+++ b/docs/source/concepts/execution-and-parallelism.md
@@ -114,6 +114,7 @@ That includes:
 - `dask.distributed.Client().get_executor()`
 - `mpi4py.futures.MPIPoolExecutor()`
 - `loky.get_reusable_executor()`
+- `executorlib.SingleNodeExecutor`, `executorlib.SlurmClusterExecutor`, `executorlib.SlurmJobExecutor`, `executorlib.FluxClusterExecutor`, `executorlib.FluxJobExecutor`
 
 ```
 

--- a/example.ipynb
+++ b/example.ipynb
@@ -805,6 +805,7 @@
     "- `dask.distributed.Client().get_executor()`\n",
     "- `mpi4py.futures.MPIPoolExecutor()`\n",
     "- `loky.get_reusable_executor()`\n",
+    "- `executorlib.SingleNodeExecutor`, `executorlib.SlurmClusterExecutor`, `executorlib.SlurmJobExecutor`, `executorlib.FluxClusterExecutor`, `executorlib.FluxJobExecutor`\n",
     "\n",
     "To just change the number of cores while using the default executor, use"
    ]

--- a/pipefunc/_utils.py
+++ b/pipefunc/_utils.py
@@ -337,7 +337,7 @@ def get_ncores(ex: Executor) -> int:
             ncores = ex.max_workers
             if ncores is None:
                 # In case the number of workers is not defined
-                return 1 
+                return 1
             return ncores
     msg = f"Cannot get number of cores for {ex.__class__}"
     raise TypeError(msg)

--- a/pipefunc/_utils.py
+++ b/pipefunc/_utils.py
@@ -330,7 +330,7 @@ def get_ncores(ex: Executor) -> int:  # noqa: PLR0911, PLR0912
             # This could be better but since there is `cores`, `cores_per_node`,
             # and `nodes`; and they can be `None`, we just return 1 for now.
             return 1
-    if is_imported("executorlib"):
+    if is_imported("executorlib"):  # pragma: no cover
         import executorlib
 
         if isinstance(ex, executorlib.BaseExecutor):

--- a/pipefunc/_utils.py
+++ b/pipefunc/_utils.py
@@ -330,6 +330,15 @@ def get_ncores(ex: Executor) -> int:
             # This could be better but since there is `cores`, `cores_per_node`,
             # and `nodes`; and they can be `None`, we just return 1 for now.
             return 1
+    if is_imported("executorlib"):
+        import executorlib
+
+        if isinstance(ex, executorlib.BaseExecutor):
+            ncores = ex.max_workers
+            if ncores is None:
+                # In case the number of workers is not defined
+                return 1 
+            return ncores
     msg = f"Cannot get number of cores for {ex.__class__}"
     raise TypeError(msg)
 

--- a/pipefunc/_utils.py
+++ b/pipefunc/_utils.py
@@ -298,7 +298,7 @@ def is_imported(package: str) -> bool:
     return package in sys.modules
 
 
-def get_ncores(ex: Executor) -> int:
+def get_ncores(ex: Executor) -> int:  # noqa: PLR0911, PLR0912
     """Return the maximum number of cores that an executor can use."""
     if isinstance(ex, ProcessPoolExecutor | ThreadPoolExecutor):
         return ex._max_workers  # type: ignore[union-attr]
@@ -335,8 +335,7 @@ def get_ncores(ex: Executor) -> int:
 
         if isinstance(ex, executorlib.BaseExecutor):
             ncores = ex.max_workers
-            if ncores is None:
-                # In case the number of workers is not defined
+            if ncores is None:  # In case the number of workers is not defined
                 return 1
             return ncores
     msg = f"Cannot get number of cores for {ex.__class__}"

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -954,7 +954,7 @@ def _maybe_execute_single(
 ) -> Any:
     args = (func, kwargs, store, cache)  # args for _execute_single
     ex = _executor_for_func(func, executor)
-    if ex:
+    if ex is not None:
         assert executor is not None
         ex = maybe_update_slurm_executor_single(func, ex, executor, kwargs)
         return _submit(_execute_single, ex, status, progress, 1, *args)


### PR DESCRIPTION
Hi @basnijholt, I would like to use pipefunc with my https://github.com/pyiron/executorlib library. Executorlib uses the `concurrent.futures.Executor` interface to distribute Python functions in the high performance computing (HPC) context by directly interfacing with HPC queuing systems like SLURM and flux, supporting both the submission of Python functions from the login node to compute nodes (in the SLURM context using the `sbatch` command) and the distribution of Python functions within a give queuing system allocation (in the SLURM context using the `srun` command).

In this pull request I add the corresponding functionality to support the Executor classes from the executorlib package.