### PR TITLE
BUG:  pipeline.subpipeline handles optional inputs as required when validating new root args

### DIFF
--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -2162,12 +2162,15 @@ class Pipeline:
             pipeline.drop(f=f)
 
         if inputs is not None:
-            new_root_args = set(pipeline.topological_generations.root_args)
-            if not new_root_args.issubset(inputs):
+            # subtract inputs with default values as they are not required
+            new_required_root_args = set(pipeline.topological_generations.root_args) - set(
+                pipeline.defaults.keys(),
+            )
+            if not new_required_root_args.issubset(inputs):
                 outputs = {f.output_name for f in pipeline.functions}
                 msg = (
                     f"Cannot construct a partial pipeline with `{outputs=}`"
-                    f" and `{inputs=}`, it would require `{new_root_args}`."
+                    f" and `{inputs=}`, it would require `{new_required_root_args}`."
                 )
                 raise ValueError(msg)
 

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -2163,9 +2163,8 @@ class Pipeline:
 
         if inputs is not None:
             # subtract inputs with default values as they are not required
-            new_required_root_args = set(pipeline.topological_generations.root_args) - set(
-                pipeline.defaults.keys(),
-            )
+            root_args = set(pipeline.topological_generations.root_args)
+            new_required_root_args = root_args - pipeline.defaults.keys()
             if not new_required_root_args.issubset(inputs):
                 outputs = {f.output_name for f in pipeline.functions}
                 msg = (

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -595,6 +595,19 @@ def test_subpipeline() -> None:
         pipeline.subpipeline()
 
 
+def test_subpipeline_with_defaults() -> None:
+    @pipefunc(output_name=("c", "d"))
+    def f(a: int, b: int = 1):
+        return a + b, 1
+
+    @pipefunc(output_name="z")
+    def g(c, d):
+        return c + d
+
+    pipeline = Pipeline([f, g])
+    pipeline.subpipeline({"a"}, {"z"})
+
+
 def test_nest_all() -> None:
     @pipefunc(output_name="c")
     def f(a, b):


### PR DESCRIPTION
Changed validation logic of root_args for subpipeline to fix #825 .

Added unit test which initially failed due to the bug but should now pass.

