### PR TITLE
ENH: Add support for suppressing runtime error logs in `PipeFunc` and `Pipeline` classes

### DIFF
--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -91,9 +91,9 @@ class PipeFunc(Generic[T]):
         Profiling is only available for sequential execution.
     debug
         Flag indicating whether debug information should be printed.
-    suppress_error_log
+    print_error
         Flag indicating whether errors raised during the function execution should
-        be logged to the console.
+        be printed.
     cache
         Flag indicating whether the wrapped function should be cached.
     mapspec
@@ -212,7 +212,7 @@ class PipeFunc(Generic[T]):
         bound: dict[str, Any] | None = None,
         profile: bool = False,
         debug: bool = False,
-        suppress_error_log: bool = False,
+        print_error: bool = False,
         cache: bool = False,
         mapspec: str | MapSpec | None = None,
         internal_shape: int | Literal["?"] | ShapeTuple | None = None,
@@ -233,7 +233,7 @@ class PipeFunc(Generic[T]):
         self.__name__ = _get_name(func)
         self._output_name: OUTPUT_TYPE = output_name
         self.debug = debug
-        self.suppress_error_log = suppress_error_log
+        self.print_error = print_error
         self.cache = cache
         self.mapspec = _maybe_mapspec(mapspec)
         self.internal_shape: int | Literal["?"] | ShapeTuple | None = internal_shape
@@ -641,7 +641,7 @@ class PipeFunc(Generic[T]):
             "defaults": self._defaults,
             "bound": self._bound,
             "profile": self._profile,
-            "suppress_error_log": self.suppress_error_log,
+            "print_error": self.print_error,
             "debug": self.debug,
             "cache": self.cache,
             "mapspec": self.mapspec,
@@ -705,7 +705,7 @@ class PipeFunc(Generic[T]):
             try:
                 result = self.func(*args, **kwargs)
             except Exception as e:
-                if not self.suppress_error_log:
+                if not self.print_error:
                     print(
                         f"An error occurred while calling the function `{self.__name__}`"
                         f" with the arguments `{args=}` and `{kwargs=}`.",
@@ -977,7 +977,7 @@ def pipefunc(
     bound: dict[str, Any] | None = None,
     profile: bool = False,
     debug: bool = False,
-    suppress_error_log: bool = False,
+    print_error: bool = False,
     cache: bool = False,
     mapspec: str | MapSpec | None = None,
     internal_shape: int | Literal["?"] | ShapeTuple | None = None,
@@ -1022,9 +1022,9 @@ def pipefunc(
         Flag indicating whether the decorated function should be profiled.
     debug
         Flag indicating whether debug information should be printed.
-    suppress_error_log
+    print_error
         Flag indicating whether errors raised during the function execution should
-        be logged to the console.
+        be printed.
     cache
         Flag indicating whether the decorated function should be cached.
     mapspec
@@ -1151,7 +1151,7 @@ def pipefunc(
             bound=bound,
             profile=profile,
             debug=debug,
-            suppress_error_log=suppress_error_log,
+            print_error=print_error,
             cache=cache,
             mapspec=mapspec,
             internal_shape=internal_shape,
@@ -1276,7 +1276,7 @@ class NestedPipeFunc(PipeFunc):
         self.variant: dict[str | None, str] = _ensure_variant(variant)
         self._output_picker = None
         self._profile = False
-        self.suppress_error_log = False
+        self.print_error = False
         self._renames: dict[str, str] = renames or {}
         self._bound: dict[str, Any] = bound or {}
         self._defaults: dict[str, Any] = {

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -705,7 +705,7 @@ class PipeFunc(Generic[T]):
             try:
                 result = self.func(*args, **kwargs)
             except Exception as e:
-                if not self.print_error:
+                if self.print_error:
                     print(
                         f"An error occurred while calling the function `{self.__name__}`"
                         f" with the arguments `{args=}` and `{kwargs=}`.",

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -91,6 +91,9 @@ class PipeFunc(Generic[T]):
         Profiling is only available for sequential execution.
     debug
         Flag indicating whether debug information should be printed.
+    suppress_error_log
+        Flag indicating whether errors raised during the function execution should
+        be logged to the console.
     cache
         Flag indicating whether the wrapped function should be cached.
     mapspec
@@ -209,6 +212,7 @@ class PipeFunc(Generic[T]):
         bound: dict[str, Any] | None = None,
         profile: bool = False,
         debug: bool = False,
+        suppress_error_log: bool = False,
         cache: bool = False,
         mapspec: str | MapSpec | None = None,
         internal_shape: int | Literal["?"] | ShapeTuple | None = None,
@@ -229,6 +233,7 @@ class PipeFunc(Generic[T]):
         self.__name__ = _get_name(func)
         self._output_name: OUTPUT_TYPE = output_name
         self.debug = debug
+        self.suppress_error_log = suppress_error_log
         self.cache = cache
         self.mapspec = _maybe_mapspec(mapspec)
         self.internal_shape: int | Literal["?"] | ShapeTuple | None = internal_shape
@@ -699,10 +704,11 @@ class PipeFunc(Generic[T]):
             try:
                 result = self.func(*args, **kwargs)
             except Exception as e:
-                print(
-                    f"An error occurred while calling the function `{self.__name__}`"
-                    f" with the arguments `{args=}` and `{kwargs=}`.",
-                )
+                if not self.suppress_error_log:
+                    print(
+                        f"An error occurred while calling the function `{self.__name__}`"
+                        f" with the arguments `{args=}` and `{kwargs=}`.",
+                    )
                 self.error_snapshot = ErrorSnapshot(self.func, e, args, kwargs)
                 raise
 
@@ -970,6 +976,7 @@ def pipefunc(
     bound: dict[str, Any] | None = None,
     profile: bool = False,
     debug: bool = False,
+    suppress_error_log: bool = False,
     cache: bool = False,
     mapspec: str | MapSpec | None = None,
     internal_shape: int | Literal["?"] | ShapeTuple | None = None,
@@ -1014,6 +1021,9 @@ def pipefunc(
         Flag indicating whether the decorated function should be profiled.
     debug
         Flag indicating whether debug information should be printed.
+    suppress_error_log
+        Flag indicating whether errors raised during the function execution should
+        be logged to the console.
     cache
         Flag indicating whether the decorated function should be cached.
     mapspec
@@ -1140,6 +1150,7 @@ def pipefunc(
             bound=bound,
             profile=profile,
             debug=debug,
+            suppress_error_log=suppress_error_log,
             cache=cache,
             mapspec=mapspec,
             internal_shape=internal_shape,

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -641,6 +641,7 @@ class PipeFunc(Generic[T]):
             "defaults": self._defaults,
             "bound": self._bound,
             "profile": self._profile,
+            "suppress_error_log": self.suppress_error_log,
             "debug": self.debug,
             "cache": self.cache,
             "mapspec": self.mapspec,
@@ -1275,6 +1276,7 @@ class NestedPipeFunc(PipeFunc):
         self.variant: dict[str | None, str] = _ensure_variant(variant)
         self._output_picker = None
         self._profile = False
+        self.suppress_error_log = False
         self._renames: dict[str, str] = renames or {}
         self._bound: dict[str, Any] = bound or {}
         self._defaults: dict[str, Any] = {

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -212,7 +212,7 @@ class PipeFunc(Generic[T]):
         bound: dict[str, Any] | None = None,
         profile: bool = False,
         debug: bool = False,
-        print_error: bool = False,
+        print_error: bool = True,
         cache: bool = False,
         mapspec: str | MapSpec | None = None,
         internal_shape: int | Literal["?"] | ShapeTuple | None = None,
@@ -977,7 +977,7 @@ def pipefunc(
     bound: dict[str, Any] | None = None,
     profile: bool = False,
     debug: bool = False,
-    print_error: bool = False,
+    print_error: bool = True,
     cache: bool = False,
     mapspec: str | MapSpec | None = None,
     internal_shape: int | Literal["?"] | ShapeTuple | None = None,
@@ -1276,7 +1276,7 @@ class NestedPipeFunc(PipeFunc):
         self.variant: dict[str | None, str] = _ensure_variant(variant)
         self._output_picker = None
         self._profile = False
-        self.print_error = False
+        self.print_error = True
         self._renames: dict[str, str] = renames or {}
         self._bound: dict[str, Any] = bound or {}
         self._defaults: dict[str, Any] = {

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -98,9 +98,9 @@ class Pipeline:
     debug
         Flag indicating whether debug information should be printed.
         If ``None``, the value of each PipeFunc's debug attribute is used.
-    suppress_error_log
+    print_error
         Flag indicating whether errors raised during the function execution should
-        be logged to the console.
+        be printed.
         If ``None``, the value of each PipeFunc's debug attribute is used.
     profile
         Flag indicating whether profiling information should be collected.
@@ -179,7 +179,7 @@ class Pipeline:
         *,
         lazy: bool = False,
         debug: bool | None = None,
-        suppress_error_log: bool | None = None,
+        print_error: bool | None = None,
         profile: bool | None = None,
         cache_type: Literal["lru", "hybrid", "disk", "simple"] | None = None,
         cache_kwargs: dict[str, Any] | None = None,
@@ -193,7 +193,7 @@ class Pipeline:
         self.functions: list[PipeFunc] = []
         self.lazy = lazy
         self._debug = debug
-        self._suppress_error_log = suppress_error_log
+        self._print_error = print_error
         self._profile = profile
         self._default_resources: Resources | None = Resources.maybe_from_dict(default_resources)  # type: ignore[assignment]
         self.validate_type_annotations = validate_type_annotations
@@ -291,17 +291,17 @@ class Pipeline:
                 f.debug = value
 
     @property
-    def suppress_error_log(self) -> bool | None:
-        """Flag indicating whether errors raised during the function execution should be logged to the console."""
-        return self._suppress_error_log
+    def print_error(self) -> bool | None:
+        """Flag indicating whether errors raised during the function execution should be printed."""
+        return self._print_error
 
-    @suppress_error_log.setter
-    def suppress_error_log(self, value: bool | None) -> None:
-        """Set the suppress_error_log flag for the pipeline and all functions."""
-        self._suppress_error_log = value
+    @print_error.setter
+    def print_error(self, value: bool | None) -> None:
+        """Set the print_error flag for the pipeline and all functions."""
+        self._print_error = value
         if value is not None:
             for f in self.functions:
-                f.suppress_error_log = value
+                f.print_error = value
 
     def add(self, f: PipeFunc | Callable, mapspec: str | MapSpec | None = None) -> PipeFunc:
         """Add a function to the pipeline.
@@ -347,8 +347,8 @@ class Pipeline:
         if self.debug is not None:
             f.debug = self.debug
 
-        if self.suppress_error_log is not None:
-            f.suppress_error_log = self.suppress_error_log
+        if self.print_error is not None:
+            f.print_error = self.print_error
 
         self._clear_internal_cache()  # reset cache
         self.validate()
@@ -1918,7 +1918,7 @@ class Pipeline:
             "lazy": self.lazy,
             "debug": self._debug,
             "profile": self._profile,
-            "suppress_error_log": self._suppress_error_log,
+            "print_error": self._print_error,
             "cache_type": self._cache_type,
             "cache_kwargs": self._cache_kwargs,
             "default_resources": self._default_resources,

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -98,6 +98,11 @@ class Pipeline:
     debug
         Flag indicating whether debug information should be printed.
         If ``None``, the value of each PipeFunc's debug attribute is used.
+    suppress_error_log
+    suppress_error_log
+        Flag indicating whether errors raised during the function execution should
+        be logged to the console.
+        If ``None``, the value of each PipeFunc's debug attribute is used.
     profile
         Flag indicating whether profiling information should be collected.
         If ``None``, the value of each PipeFunc's profile attribute is used.
@@ -175,6 +180,7 @@ class Pipeline:
         *,
         lazy: bool = False,
         debug: bool | None = None,
+        suppress_error_log: bool | None = None,
         profile: bool | None = None,
         cache_type: Literal["lru", "hybrid", "disk", "simple"] | None = None,
         cache_kwargs: dict[str, Any] | None = None,
@@ -188,6 +194,7 @@ class Pipeline:
         self.functions: list[PipeFunc] = []
         self.lazy = lazy
         self._debug = debug
+        self._suppress_error_log = suppress_error_log
         self._profile = profile
         self._default_resources: Resources | None = Resources.maybe_from_dict(default_resources)  # type: ignore[assignment]
         self.validate_type_annotations = validate_type_annotations
@@ -284,6 +291,19 @@ class Pipeline:
             for f in self.functions:
                 f.debug = value
 
+    @property
+    def suppress_error_log(self) -> bool | None:
+        """Flag indicating whether errors raised during the function execution should be logged to the console."""
+        return self._suppress_error_log
+
+    @suppress_error_log.setter
+    def suppress_error_log(self, value: bool | None) -> None:
+        """Set the suppress_error_log flag for the pipeline and all functions."""
+        self._suppress_error_log = value
+        if value is not None:
+            for f in self.functions:
+                f.suppress_error_log = value
+
     def add(self, f: PipeFunc | Callable, mapspec: str | MapSpec | None = None) -> PipeFunc:
         """Add a function to the pipeline.
 
@@ -327,6 +347,9 @@ class Pipeline:
 
         if self.debug is not None:
             f.debug = self.debug
+
+        if self.suppress_error_log is not None:
+            f.suppress_error_log = self.suppress_error_log
 
         self._clear_internal_cache()  # reset cache
         self.validate()

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -99,7 +99,6 @@ class Pipeline:
         Flag indicating whether debug information should be printed.
         If ``None``, the value of each PipeFunc's debug attribute is used.
     suppress_error_log
-    suppress_error_log
         Flag indicating whether errors raised during the function execution should
         be logged to the console.
         If ``None``, the value of each PipeFunc's debug attribute is used.
@@ -1919,6 +1918,7 @@ class Pipeline:
             "lazy": self.lazy,
             "debug": self._debug,
             "profile": self._profile,
+            "suppress_error_log": self._suppress_error_log,
             "cache_type": self._cache_type,
             "cache_kwargs": self._cache_kwargs,
             "default_resources": self._default_resources,

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -101,7 +101,7 @@ class Pipeline:
     print_error
         Flag indicating whether errors raised during the function execution should
         be printed.
-        If ``None``, the value of each PipeFunc's debug attribute is used.
+        If ``None``, the value of each PipeFunc's print_error attribute is used.
     profile
         Flag indicating whether profiling information should be collected.
         If ``None``, the value of each PipeFunc's profile attribute is used.

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -48,9 +48,9 @@ class VariantPipeline:
     debug
         Flag indicating whether debug information should be printed.
         If ``None``, the value of each PipeFunc's debug attribute is used.
-    suppress_error_log
+    print_error
         Flag indicating whether errors raised during the function execution should
-        be logged to the console.
+        be printed.
         If ``None``, the value of each PipeFunc's debug attribute is used.
     profile
         Flag indicating whether profiling information should be collected.
@@ -170,7 +170,7 @@ class VariantPipeline:
         default_variant: str | dict[str | None, str] | None = None,
         lazy: bool = False,
         debug: bool | None = None,
-        suppress_error_log: bool | None = None,
+        print_error: bool | None = None,
         profile: bool | None = None,
         cache_type: Literal["lru", "hybrid", "disk", "simple"] | None = None,
         cache_kwargs: dict[str, Any] | None = None,
@@ -185,7 +185,7 @@ class VariantPipeline:
         self.default_variant = default_variant
         self.lazy = lazy
         self.debug = debug
-        self.suppress_error_log = suppress_error_log
+        self.print_error = print_error
         self.profile = profile
         self.cache_type = cache_type
         self.cache_kwargs = cache_kwargs
@@ -278,7 +278,7 @@ class VariantPipeline:
             new_functions,  # type: ignore[arg-type]
             lazy=kwargs.get("lazy", self.lazy),
             debug=kwargs.get("debug", self.debug),
-            suppress_error_log=kwargs.get("suppress_error_log", self.suppress_error_log),
+            print_error=kwargs.get("print_error", self.print_error),
             profile=kwargs.get("profile", self.profile),
             cache_type=kwargs.get("cache_type", self.cache_type),
             cache_kwargs=kwargs.get("cache_kwargs", self.cache_kwargs),
@@ -347,7 +347,7 @@ class VariantPipeline:
             "functions": self.functions,
             "lazy": self.lazy,
             "debug": self.debug,
-            "suppress_error_log": self.suppress_error_log,
+            "print_error": self.print_error,
             "profile": self.profile,
             "cache_type": self.cache_type,
             "cache_kwargs": self.cache_kwargs,

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -48,6 +48,10 @@ class VariantPipeline:
     debug
         Flag indicating whether debug information should be printed.
         If ``None``, the value of each PipeFunc's debug attribute is used.
+    suppress_error_log
+        Flag indicating whether errors raised during the function execution should
+        be logged to the console.
+        If ``None``, the value of each PipeFunc's debug attribute is used.
     profile
         Flag indicating whether profiling information should be collected.
         If ``None``, the value of each PipeFunc's profile attribute is used.
@@ -166,6 +170,7 @@ class VariantPipeline:
         default_variant: str | dict[str | None, str] | None = None,
         lazy: bool = False,
         debug: bool | None = None,
+        suppress_error_log: bool | None = None,
         profile: bool | None = None,
         cache_type: Literal["lru", "hybrid", "disk", "simple"] | None = None,
         cache_kwargs: dict[str, Any] | None = None,
@@ -180,6 +185,7 @@ class VariantPipeline:
         self.default_variant = default_variant
         self.lazy = lazy
         self.debug = debug
+        self.suppress_error_log = suppress_error_log
         self.profile = profile
         self.cache_type = cache_type
         self.cache_kwargs = cache_kwargs
@@ -272,6 +278,7 @@ class VariantPipeline:
             new_functions,  # type: ignore[arg-type]
             lazy=kwargs.get("lazy", self.lazy),
             debug=kwargs.get("debug", self.debug),
+            suppress_error_log=kwargs.get("suppress_error_log", self.suppress_error_log),
             profile=kwargs.get("profile", self.profile),
             cache_type=kwargs.get("cache_type", self.cache_type),
             cache_kwargs=kwargs.get("cache_kwargs", self.cache_kwargs),
@@ -340,6 +347,7 @@ class VariantPipeline:
             "functions": self.functions,
             "lazy": self.lazy,
             "debug": self.debug,
+            "suppress_error_log": self.suppress_error_log,
             "profile": self.profile,
             "cache_type": self.cache_type,
             "cache_kwargs": self.cache_kwargs,

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -51,7 +51,7 @@ class VariantPipeline:
     print_error
         Flag indicating whether errors raised during the function execution should
         be printed.
-        If ``None``, the value of each PipeFunc's debug attribute is used.
+        If ``None``, the value of each PipeFunc's print_error attribute is used.
     profile
         Flag indicating whether profiling information should be collected.
         If ``None``, the value of each PipeFunc's profile attribute is used.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -694,19 +694,19 @@ def test_overwrite_flags() -> None:
     pipeline = Pipeline([f])
     assert not f.debug
     assert not f.profile
-    assert not f.suppress_error_log
+    assert f.print_error
     pipeline.debug = True
     pipeline.profile = True
-    pipeline.suppress_error_log = True
+    pipeline.print_error = False
     assert pipeline["c"].debug
     assert pipeline["c"].profile
-    assert pipeline["c"].suppress_error_log
+    assert not pipeline["c"].print_error
 
     f = func.copy()
-    pipeline = Pipeline([f], debug=True, profile=True, suppress_error_log=True)
+    pipeline = Pipeline([f], debug=True, profile=True, print_error=False)
     assert pipeline["c"].debug
     assert pipeline["c"].profile
-    assert pipeline["c"].suppress_error_log
+    assert not pipeline["c"].print_error
 
 
 def test_nesting_funcs_with_bound() -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -685,7 +685,7 @@ def test_unhashable_defaults() -> None:
 
 
 @pytest.mark.skipif(not has_psutil, reason="psutil not installed")
-def test_set_debug_and_profile() -> None:
+def test_set_overwrite_attributes() -> None:
     @pipefunc(output_name="c")
     def f(a, b):
         return a + b
@@ -693,10 +693,13 @@ def test_set_debug_and_profile() -> None:
     pipeline = Pipeline([f])
     assert not f.debug
     assert not f.profile
+    assert not f.suppress_error_log
     pipeline.debug = True
     pipeline.profile = True
+    pipeline.suppress_error_log = True
     assert pipeline["c"].debug
     assert pipeline["c"].profile
+    assert pipeline["c"].suppress_error_log
 
 
 def test_nesting_funcs_with_bound() -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -685,11 +685,12 @@ def test_unhashable_defaults() -> None:
 
 
 @pytest.mark.skipif(not has_psutil, reason="psutil not installed")
-def test_set_overwrite_attributes() -> None:
+def test_overwrite_flags() -> None:
     @pipefunc(output_name="c")
-    def f(a, b):
+    def func(a, b):
         return a + b
 
+    f = func.copy()
     pipeline = Pipeline([f])
     assert not f.debug
     assert not f.profile
@@ -697,6 +698,12 @@ def test_set_overwrite_attributes() -> None:
     pipeline.debug = True
     pipeline.profile = True
     pipeline.suppress_error_log = True
+    assert pipeline["c"].debug
+    assert pipeline["c"].profile
+    assert pipeline["c"].suppress_error_log
+
+    f = func.copy()
+    pipeline = Pipeline([f], debug=True, profile=True, suppress_error_log=True)
     assert pipeline["c"].debug
     assert pipeline["c"].profile
     assert pipeline["c"].suppress_error_log


### PR DESCRIPTION
In the projects where I use `pipefunc` I often deal with massive numpy arrays for large parameterscans or have pipelines with many input arguments.

When I try to debug Runtime Errors in these pipelines with print-statements, I therefore often find myself looking for a needle within a haystack of array values.

There currently is no way to suppress this behaviour which is why I would like to add an attribute simmilar to the `debug` or `profile` flag to the `Pipefunc` constructor in order to suppress this warning for less verbose outputs.

I'm open for suggestions regarding this option. For instance, I think another suitable approach would be to let users inject a `logging.Logger` object to the `Pipeline` and replace the print statements with its methods. But I'm not aware about any limitations this approach might have with parallel `Pipeline.map`.
