### PR TITLE
ENH: Allow for a scope-keyed nested dictionary as `update_defaults` input

### DIFF
--- a/docs/source/concepts/parameter-scopes.md
+++ b/docs/source/concepts/parameter-scopes.md
@@ -90,6 +90,7 @@ Some key things to note:
 - Applying a scope to a parameter that is already in a scope will _replace_ the existing scope with the new one.
 - Using scopes makes it possible to use the same parameter names in different contexts without conflicts.
 - Scopes are purely a naming mechanism and do not affect the actual function execution.
+- **Scope names and parameter names cannot overlap**. For example, you cannot have both a scope named `"data"` and a parameter named `"data"`, as this would create ambiguity when using the nested dictionary syntax `{"data": {...}}`.
 
 Parameter scopes are a convenient way to organize complex pipelines and make them more readable by grouping related parameters together.
 They also help avoid naming conflicts and make it easier to reason about the data flow between functions.

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -1221,13 +1221,14 @@ class Pipeline:
             },
         ):
             overlap_str = ", ".join(sorted(overlap))
-            msg = f"The parameter names: `{overlap_str}`. Have been defined flattened and scope-keyed."
+            msg = (
+                f"Conflicting definitions for `{overlap_str}`:"
+                " found both flattened ('scope.param') and nested ({'scope': {'param': ...}}) formats."
+            )
             raise ValueError(msg)
 
         defaults = self._flatten_scopes(defaults)
-
         unused = set(defaults.keys())
-
         for f in self.functions:
             update = {k: v for k, v in defaults.items() if k in f.parameters if k not in f.bound}
             unused -= set(update.keys())

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -1213,13 +1213,13 @@ class Pipeline:
             defaults will be added to the existing defaults.
 
         """
-        if overlap := defaults.keys() & {
-            parameter
-            for f in self.functions
-            for parameter in f._flatten_scopes(
-                {scope: defaults[scope] for scope in defaults.keys() & f.parameter_scopes},
-            )
-        }:
+        if overlap := defaults.keys() & self._flatten_scopes(
+            {
+                scope: scoped_defaults
+                for scope, scoped_defaults in defaults.items()
+                if scope in self.scopes
+            },
+        ):
             overlap_str = ", ".join(sorted(overlap))
             msg = f"The parameter names: `{overlap_str}`. Have been defined flattened and scope-keyed."
             raise ValueError(msg)

--- a/pipefunc/map/_prepare.py
+++ b/pipefunc/map/_prepare.py
@@ -62,6 +62,7 @@ def prepare_run(
         msg = "Cannot use an executor without `parallel=True`."
         raise ValueError(msg)
     inputs = maybe_pydantic_model_to_dict(inputs)
+    pipeline._validate_scoped_parameters(inputs)
     inputs = pipeline._flatten_scopes(inputs)
     if auto_subpipeline or output_names is not None:
         pipeline = pipeline.subpipeline(set(inputs), output_names)

--- a/tests/test_pipeline_update.py
+++ b/tests/test_pipeline_update.py
@@ -355,7 +355,7 @@ def test_update_scoped_defaults() -> None:
     updated_pipeline = pipeline.copy()
     with pytest.raises(
         ValueError,
-        match="The parameter names: `scope.a`. Have been defined flattened and scope-keyed.",
+        match="Conflicting definitions for `scope.a`: found both flattened",
     ):
         updated_pipeline.update_defaults({"scope.a": 1, "scope": {"a": 1}})
 

--- a/tests/test_pipeline_update.py
+++ b/tests/test_pipeline_update.py
@@ -286,3 +286,90 @@ def test_update_scope_from_faq() -> None:
     results = pipeline.map(inputs=kwargs, parallel=False, storage="dict")
     assert results["baz.z"].output == 15
     assert pipeline(foo={"a": 1, "b": 2}, bar={"a": 3}, b=4) == 15
+
+
+def test_update_scoped_defaults() -> None:
+    def f(val: int, a: int = 1) -> int:
+        return val + a
+
+    @pipefunc("g", scope="scope")
+    def g(val: int, b: int = 2) -> int:
+        return val * b
+
+    @pipefunc("g")
+    def h(val: int, b: int = 2) -> int:
+        return val - b
+
+    pipeline = Pipeline([PipeFunc(f, "f", scope="scope"), PipeFunc(f, "f"), g, h])
+
+    assert pipeline["scope.f"].defaults == {"scope.a": 1}
+    assert pipeline["scope.g"].defaults == {"scope.b": 2}
+    assert pipeline["f"].defaults == {"a": 1}
+    assert pipeline["g"].defaults == {"b": 2}
+
+    # Only update unscoped values
+    updated_pipeline = pipeline.copy()
+    updated_pipeline.update_defaults({"a": 3, "b": 4})
+
+    assert updated_pipeline["scope.f"].defaults == {"scope.a": 1}
+    assert updated_pipeline["scope.g"].defaults == {"scope.b": 2}
+    assert updated_pipeline["f"].defaults == {"a": 3}
+    assert updated_pipeline["g"].defaults == {"b": 4}
+
+    # Only update scoped values as scope-keyed
+    updated_pipeline = pipeline.copy()
+    updated_pipeline.update_defaults({"scope": {"a": 3, "b": 4}})
+
+    assert updated_pipeline["scope.f"].defaults == {"scope.a": 3}
+    assert updated_pipeline["scope.g"].defaults == {"scope.b": 4}
+    assert updated_pipeline["f"].defaults == {"a": 1}
+    assert updated_pipeline["g"].defaults == {"b": 2}
+
+    # Only update scoped values as flat-keyed
+    updated_pipeline = pipeline.copy()
+    updated_pipeline.update_defaults({"scope.a": 3, "scope.b": 4})
+
+    assert updated_pipeline["scope.f"].defaults == {"scope.a": 3}
+    assert updated_pipeline["scope.g"].defaults == {"scope.b": 4}
+    assert updated_pipeline["f"].defaults == {"a": 1}
+    assert updated_pipeline["g"].defaults == {"b": 2}
+
+    # Update both methods simultaneously
+    updated_pipeline = pipeline.copy()
+    updated_pipeline.update_defaults({"a": 10, "b": 20, "scope": {"a": 3, "b": 4}})
+
+    assert updated_pipeline["scope.f"].defaults == {"scope.a": 3}
+    assert updated_pipeline["scope.g"].defaults == {"scope.b": 4}
+    assert updated_pipeline["f"].defaults == {"a": 10}
+    assert updated_pipeline["g"].defaults == {"b": 20}
+
+    updated_pipeline = pipeline.copy()
+    updated_pipeline.update_defaults({"a": 10, "b": 20, "scope.a": 3, "scope.b": 4})
+
+    assert updated_pipeline["scope.f"].defaults == {"scope.a": 3}
+    assert updated_pipeline["scope.g"].defaults == {"scope.b": 4}
+    assert updated_pipeline["f"].defaults == {"a": 10}
+    assert updated_pipeline["g"].defaults == {"b": 20}
+
+    # Try to update a value scope based and flat
+    updated_pipeline = pipeline.copy()
+    with pytest.raises(
+        ValueError,
+        match="The parameter names: `scope.a`. Have been defined flattened and scope-keyed.",
+    ):
+        updated_pipeline.update_defaults({"scope.a": 1, "scope": {"a": 1}})
+
+    # Try to update a non-existing scope/value
+    updated_pipeline = pipeline.copy()
+    with pytest.raises(
+        ValueError,
+        match="Unused keyword arguments: `DOES_NOT_EXIST`. These are not settable defaults.",
+    ):
+        updated_pipeline.update_defaults({"DOES_NOT_EXIST": 1})
+
+    updated_pipeline = pipeline.copy()
+    with pytest.raises(
+        ValueError,
+        match="Unused keyword arguments: `scope.DOES_NOT_EXIST`. These are not settable defaults.",
+    ):
+        updated_pipeline.update_defaults({"scope": {"DOES_NOT_EXIST": 1}})


### PR DESCRIPTION
Closes #810.

I initially thought that the approach in the issue would not be possible, but I was not aware that the parameter scopes and parameter names in a pipeline have to be disjoint which makes it possible to identify a string as either a scope name or a parameter name.

- I have added the `Pipeline.scopes` property for convenience, but we can also ditch that if its not desired.

- Besides that, there were only changes necessary to the `Pipeline.update_defaults` method in which the input dictionary is preprocessed by flattening the sub-dictionaries that resemble scoped updates with `Pipefunc._flatten_scopes`.

> It would be a bit more efficient to get the intersection of `Pipeline.scopes` and `defaults.keys()` and map the associated sub-dictionary of defaults to "scope.key": val. But then we would re-implement the logic mapping a scope, parameter name pair to a flat parameter name defined in the `Pipefunc` class in the `Pipeline` class aswell.

- I have also changed the annotation of `Pipeline.update_defaults`

https://github.com/pipefunc/pipefunc/blob/37b9b4dbe83a14ed000921e60e8451418f671e5a/pipefunc/_pipeline/_base.py#L1192-L1197

so that it indicates that a nested dictionary can also be passed.

- The method will now raise a `ValueError` if a certain scoped parameter is referenced as scope-keyed and flat-keyed e.g.

```python
# Raises ValueError: The parameter names: `scope.a`. Have been defined flattened and scope-keyed.
pipeline.update_defaults({"scope.a": 1, "scope": {"a" : 1}})
```