### PR TITLE
ENH: Add info about unresolved variants when `VariantPipeline.__getattr__` raises an `AttributeError`

### DIFF
--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -515,26 +515,26 @@ class VariantPipeline:
 
     def __getattr__(self, name: str) -> None:
         if name in Pipeline.__dict__:
-            unresolved_variants = {
+            unresolved = {
                 group: variants
                 for group, variants in self.variants_mapping().items()
                 if len(variants) > 1
             }
-            unresolved_variants_info = ""
 
-            if variants := unresolved_variants.pop(None, None):
-                unresolved_variants_info += f" The variants {variants} are not yet resolved."
-            if unresolved_variants:
-                unresolved_groups_str = ", ".join(
-                    [f"{group} = {variants}" for group, variants in unresolved_variants.items()],
+            if unresolved:
+                parts = []
+                if None in unresolved:
+                    parts.append(f"variants {unresolved[None]}")
+                parts.extend(
+                    f"variant group `{g} = {v}`" for g, v in unresolved.items() if g is not None
                 )
-                unresolved_variants_info += (
-                    f" The variant group(s) {unresolved_groups_str} are not yet resolved."
-                )
+                variants_info = f" The {' and '.join(parts)} are not yet resolved."
+            else:
+                variants_info = ""
 
             msg = (
                 "This is a `VariantPipeline`, not a `Pipeline`."
-                f"{unresolved_variants_info}"
+                f"{variants_info}"
                 " Use `VariantPipeline.with_variant(...)` to instanciate a Pipeline first."
                 f" Then access `Pipeline.{name}` again."
             )

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -534,7 +534,7 @@ class VariantPipeline:
 
             msg = (
                 "This is a `VariantPipeline`, not a `Pipeline`."
-                f"({unresolved_variants_info})"
+                f"{unresolved_variants_info}"
                 " Use `VariantPipeline.with_variant(...)` to instanciate a Pipeline first."
                 f" Then access `Pipeline.{name}` again."
             )

--- a/pipefunc/_variant_pipeline.py
+++ b/pipefunc/_variant_pipeline.py
@@ -515,10 +515,28 @@ class VariantPipeline:
 
     def __getattr__(self, name: str) -> None:
         if name in Pipeline.__dict__:
+            unresolved_variants = {
+                group: variants
+                for group, variants in self.variants_mapping().items()
+                if len(variants) > 1
+            }
+            unresolved_variants_info = ""
+
+            if variants := unresolved_variants.pop(None, None):
+                unresolved_variants_info += f" The variants {variants} are not yet resolved."
+            if unresolved_variants:
+                unresolved_groups_str = ", ".join(
+                    [f"{group} = {variants}" for group, variants in unresolved_variants.items()],
+                )
+                unresolved_variants_info += (
+                    f" The variant group(s) {unresolved_groups_str} are not yet resolved."
+                )
+
             msg = (
                 "This is a `VariantPipeline`, not a `Pipeline`."
-                " Use `pipeline.with_variant(...)` to select a variant first."
-                f" Then call `variant_pipeline.{name}` again."
+                f"({unresolved_variants_info})"
+                " Use `VariantPipeline.with_variant(...)` to instanciate a Pipeline first."
+                f" Then access `Pipeline.{name}` again."
             )
             raise AttributeError(msg)
         default_msg = f"'VariantPipeline' object has no attribute '{name}'"

--- a/tests/test_variant_pipeline.py
+++ b/tests/test_variant_pipeline.py
@@ -241,10 +241,36 @@ def test_getattr_for_pipeline_attributes() -> None:
     def f(a, b):
         return a + b
 
+    @pipefunc(output_name="c", variant={"op1": "mul"})
+    def f2(a, b):
+        return a * b
+
+    @pipefunc(output_name="c", variant="variant")
+    def h(a, b):
+        return a + b
+
+    @pipefunc(output_name="c", variant="variant2")
+    def i(a, b):
+        return a + b
+
     pipeline = VariantPipeline([f])
     with pytest.raises(
         AttributeError,
         match="This is a `VariantPipeline`, not a `Pipeline`",
+    ):
+        _ = pipeline.map  # type: ignore[attr-defined]
+
+    pipeline = VariantPipeline([h, i])
+    with pytest.raises(
+        AttributeError,
+        match="This is a `VariantPipeline`, not a `Pipeline`. The variants",
+    ):
+        _ = pipeline.map  # type: ignore[attr-defined]
+
+    pipeline = VariantPipeline([f, f2])
+    with pytest.raises(
+        AttributeError,
+        match="This is a `VariantPipeline`, not a `Pipeline`. The variant group",
     ):
         _ = pipeline.map  # type: ignore[attr-defined]
 


### PR DESCRIPTION
Everytime I encounter the Error

``` 
This is a `VariantPipeline`, not a `Pipeline`. Use `pipeline.with_variant(...)` to select a variant first. Then call `variant_pipeline.{name}` again.
```

it's not because I forgot that a certain method is not defined for `VariantPipeline` but because I've called `VariantPipeline.with_variant`, expecting to recive a `Pipeline` instance _but I've forgotten to specify that one variant that I've included into the pipeline_.

I think it would improve the UX a lot if the error message immediately specifies which variants of the pipeline are unresolved so that you don't have to debug with something like `print(pipeline.variant_mappings())` or go through all of the `PipeFunc`s that were included in the `VariantPipeline`'s constructor. 

In my case I pass nearly all of the `Pipefunc`s of my codebase into a `VariantPipeline` and from there narrow it down to the specific workflow I need which includes several variant groups making it easy forget to specify a single variant.

> Maybe it would also be nice to have a `variant_pipeline.to_pipeline` method which only returns `Pipeline` instances or raises a `RuntimeError` if there remain unresolved variants. (As opposed to the user having to include assertion checks)?