### PR TITLE
BUG: FIX Pipeline.update_defaults with inputs that do not support __eq__

### DIFF
--- a/pipefunc/_pipeline/_validation.py
+++ b/pipefunc/_pipeline/_validation.py
@@ -36,11 +36,15 @@ def validate_consistent_defaults(
                     if default_value == arg_defaults[arg]:
                         continue
                 except Exception as e:  # noqa: BLE001
-                    warnings.warn(
-                        f"Could not compare default values for argument '{arg}' due to: {e!r}.",
-                        UserWarning,
-                        stacklevel=2,
+                    msg = (
+                        f"Could not compare default values for argument '{arg}' due to: {e!r}."
+                        " This might result in inconsistent default values if different values are"
+                        " provided for this argument in different functions."
+                        " pipefunc cannot guarantee this consistency. This may lead to unexpected"
+                        " behavior, as one of the default values will be chosen arbitrarily during"
+                        " execution."
                     )
+                    warnings.warn(msg, UserWarning, stacklevel=2)
                     continue
 
                 msg = (

--- a/tests/test_pipeline_update.py
+++ b/tests/test_pipeline_update.py
@@ -111,15 +111,11 @@ def test_update_defaults_with_non_comparable_inputs() -> None:
     ):
         Pipeline([a, b])
 
-    @pipefunc(
-        "a",
-    )
+    @pipefunc("a")
     def a2(array: np.ndarray) -> np.ndarray:
         return array + 1
 
-    @pipefunc(
-        "b",
-    )
+    @pipefunc("b")
     def b2(array: np.ndarray, factor: float) -> np.ndarray:
         return array * factor
 


### PR DESCRIPTION
In order to resolve #856 I put the comparison of default values in a `try`/`except`. If the default values cannot be compared, a warning will be emitted.