### PR TITLE
ENH: More comprehensive default value comparison with `is_equal`

### DIFF
--- a/pipefunc/_pipeline/_validation.py
+++ b/pipefunc/_pipeline/_validation.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import networkx as nx
 
 from pipefunc._pipefunc import PipeFunc
-from pipefunc._utils import at_least_tuple
+from pipefunc._utils import at_least_tuple, is_equal
 from pipefunc.typing import (
     Array,
     NoAnnotation,
@@ -33,7 +33,7 @@ def validate_consistent_defaults(
                 arg_defaults[arg] = default_value
             else:
                 try:
-                    if default_value == arg_defaults[arg]:
+                    if is_equal(default_value, arg_defaults[arg]):
                         continue
                 except Exception as e:  # noqa: BLE001
                     msg = (

--- a/pipefunc/_pipeline/_validation.py
+++ b/pipefunc/_pipeline/_validation.py
@@ -33,7 +33,7 @@ def validate_consistent_defaults(
                 arg_defaults[arg] = default_value
             else:
                 try:
-                    if is_equal(default_value, arg_defaults[arg]):
+                    if is_equal(default_value, arg_defaults[arg], on_error="raise"):
                         continue
                 except Exception as e:  # noqa: BLE001
                     msg = (

--- a/pipefunc/_utils.py
+++ b/pipefunc/_utils.py
@@ -104,7 +104,11 @@ def prod(iterable: Iterable[int]) -> int:
     return functools.reduce(operator.mul, iterable, 1)
 
 
-def _is_equal(a: Any, b: Any) -> bool | None:  # noqa: PLR0911
+def is_equal(a: Any, b: Any) -> bool | None:  # noqa: PLR0911
+    """Check if two objects are equal.
+
+    Comparisons are done using the `==` operator, but special cases are handled.
+    """
     if type(a) is not type(b):
         return False
     if isinstance(a, dict):
@@ -120,7 +124,7 @@ def _is_equal(a: Any, b: Any) -> bool | None:  # noqa: PLR0911
     if isinstance(a, list | tuple):
         if len(a) != len(b):  # type: ignore[arg-type]
             return False
-        return all(_is_equal(x, y) for x, y in zip(a, b))
+        return all(is_equal(x, y) for x, y in zip(a, b))
     if is_installed("pandas"):
         import pandas as pd
 
@@ -150,7 +154,7 @@ def equal_dicts(d1: dict[str, Any], d2: dict[str, Any], *, verbose: bool = False
     for k, v1 in d1.items():
         v2 = d2[k]
         try:
-            equal = _is_equal(v1, v2)
+            equal = is_equal(v1, v2)
         except Exception:  # noqa: BLE001
             errors.append((k, v1, v2))
         else:

--- a/tests/test_pipeline_update.py
+++ b/tests/test_pipeline_update.py
@@ -97,11 +97,16 @@ def test_update_defaults_and_renames_with_pipeline() -> None:
 
 
 def test_update_defaults_with_non_comparable_inputs() -> None:
-    @pipefunc("a", defaults={"array": np.array([1, 2, 3])})
+    class CustomType:  # noqa: PLW1641
+        def __eq__(self, _) -> bool:
+            msg = "Cannot compare CustomType instances"
+            raise ValueError(msg)
+
+    @pipefunc("a", defaults={"array": CustomType()})
     def a(array: np.ndarray) -> np.ndarray:
         return array + 1
 
-    @pipefunc("b", defaults={"array": np.array([1, 2, 3])})
+    @pipefunc("b", defaults={"array": CustomType()})
     def b(array: np.ndarray, factor: float) -> np.ndarray:
         return array * factor
 
@@ -123,7 +128,30 @@ def test_update_defaults_with_non_comparable_inputs() -> None:
         UserWarning,
         match="Could not compare default values for argument 'array'",
     ):
-        Pipeline([a2, b2]).update_defaults({"array": np.array([4, 5, 6])})
+        Pipeline([a2, b2]).update_defaults({"array": CustomType()})
+
+
+def test_update_defaults_with_nd_array() -> None:
+    @pipefunc("a", defaults={"array": np.array([1, 2, 3])})
+    def a(array: np.ndarray) -> np.ndarray:
+        return array + 1
+
+    @pipefunc("b", defaults={"array": np.array([4, 5, 6])})
+    def b(array: np.ndarray, factor: float) -> np.ndarray:
+        return array * factor
+
+    with pytest.raises(ValueError, match="Inconsistent default values for argument 'array'"):
+        Pipeline([a, b])
+
+    @pipefunc("a")
+    def a2(array: np.ndarray) -> np.ndarray:
+        return array + 1
+
+    @pipefunc("b")
+    def b2(array: np.ndarray, factor: float) -> np.ndarray:
+        return array * factor
+
+    Pipeline([a2, b2]).update_defaults({"array": np.array([4, 5, 6])})
 
 
 def test_update_renames_pipeline() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,6 @@ import pytest
 
 from pipefunc._utils import (
     _cached_load,
-    _is_equal,
     equal_dicts,
     format_args,
     format_function_call,
@@ -16,6 +15,7 @@ from pipefunc._utils import (
     handle_error,
     infer_shape,
     is_classmethod,
+    is_equal,
     is_installed,
     is_min_version,
     is_pydantic_base_model,
@@ -133,76 +133,76 @@ class CustomObject:  # noqa: PLW1641
         return False
 
 
-def test_is_equal_dict() -> None:
+def testis_equal_dict() -> None:
     d1 = {"a": 1, "b": 2}
     d2 = {"a": 1, "b": 2}
-    assert _is_equal(d1, d2)
+    assert is_equal(d1, d2)
 
     d3 = {"a": 1, "b": 3}
-    assert not _is_equal(d1, d3)
+    assert not is_equal(d1, d3)
 
     assert not equal_dicts({"a": 1}, {"a": 1, "b": 3}, verbose=True)
     assert not equal_dicts({"a": 1}, {"b": 1}, verbose=True)
     assert not equal_dicts({"a": [1]}, {"b": (1,)}, verbose=True)
 
 
-def test_is_equal_numpy_array() -> None:
+def testis_equal_numpy_array() -> None:
     a1 = np.array([1, 2, 3])
     a2 = np.array([1, 2, 3])
-    assert _is_equal(a1, a2)
+    assert is_equal(a1, a2)
 
     a3 = np.array([1, 2, 4])
-    assert not _is_equal(a1, a3)
+    assert not is_equal(a1, a3)
 
     a4 = np.array([1, 2, np.nan])
     a5 = np.array([1, 2, np.nan])
-    assert _is_equal(a4, a5)
+    assert is_equal(a4, a5)
 
 
-def test_is_equal_set() -> None:
+def testis_equal_set() -> None:
     s1 = {1, 2, 3}
     s2 = {1, 2, 3}
-    assert _is_equal(s1, s2)
+    assert is_equal(s1, s2)
 
     s3 = {1, 2, 4}
-    assert not _is_equal(s1, s3)
+    assert not is_equal(s1, s3)
 
 
-def test_is_equal_list_and_tuple() -> None:
-    assert not _is_equal([1, 2, 3], (1, 2, 3))
-    assert _is_equal([1, 2, 3], [1, 2, 3])
-    assert not _is_equal([1, 2, 3], [1, 2, 4])
-    assert _is_equal([np.array([1, 2, 3])], [np.array([1, 2, 3])])
-    assert not _is_equal([1], [1, 2])
+def testis_equal_list_and_tuple() -> None:
+    assert not is_equal([1, 2, 3], (1, 2, 3))
+    assert is_equal([1, 2, 3], [1, 2, 3])
+    assert not is_equal([1, 2, 3], [1, 2, 4])
+    assert is_equal([np.array([1, 2, 3])], [np.array([1, 2, 3])])
+    assert not is_equal([1], [1, 2])
 
 
-def test_is_equal_float() -> None:
-    assert _is_equal(1.0, 1.0)
-    assert _is_equal(1.0, 1.0000000001)
-    assert not _is_equal(1.0, 1.1)
+def testis_equal_float() -> None:
+    assert is_equal(1.0, 1.0)
+    assert is_equal(1.0, 1.0000000001)
+    assert not is_equal(1.0, 1.1)
 
 
-def test_is_equal_custom_object() -> None:
+def testis_equal_custom_object() -> None:
     obj1 = CustomObject(1)
     obj2 = CustomObject(1)
-    assert _is_equal(obj1, obj2)
+    assert is_equal(obj1, obj2)
 
     obj3 = CustomObject(2)
-    assert not _is_equal(obj1, obj3)
+    assert not is_equal(obj1, obj3)
 
 
-def test_is_equal_iterable() -> None:
-    assert _is_equal([1, 2, 3], [1, 2, 3])
-    assert not _is_equal([1, 2, 3], [1, 2, 4])
-    assert _is_equal((1, 2, 3), (1, 2, 3))
-    assert not _is_equal((1, 2, 3), (1, 2, 4))
+def testis_equal_iterable() -> None:
+    assert is_equal([1, 2, 3], [1, 2, 3])
+    assert not is_equal([1, 2, 3], [1, 2, 4])
+    assert is_equal((1, 2, 3), (1, 2, 3))
+    assert not is_equal((1, 2, 3), (1, 2, 4))
 
 
-def test_is_equal_other_types() -> None:
-    assert _is_equal(1, 1)
-    assert not _is_equal(1, 2)
-    assert _is_equal("abc", "abc")
-    assert not _is_equal("abc", "def")
+def testis_equal_other_types() -> None:
+    assert is_equal(1, 1)
+    assert not is_equal(1, 2)
+    assert is_equal("abc", "abc")
+    assert not is_equal("abc", "def")
 
 
 def test_equal_dicts_with_pandas() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -133,7 +133,7 @@ class CustomObject:  # noqa: PLW1641
         return False
 
 
-def testis_equal_dict() -> None:
+def test_is_equal_dict() -> None:
     d1 = {"a": 1, "b": 2}
     d2 = {"a": 1, "b": 2}
     assert is_equal(d1, d2)
@@ -146,7 +146,7 @@ def testis_equal_dict() -> None:
     assert not equal_dicts({"a": [1]}, {"b": (1,)}, verbose=True)
 
 
-def testis_equal_numpy_array() -> None:
+def test_is_equal_numpy_array() -> None:
     a1 = np.array([1, 2, 3])
     a2 = np.array([1, 2, 3])
     assert is_equal(a1, a2)
@@ -159,7 +159,7 @@ def testis_equal_numpy_array() -> None:
     assert is_equal(a4, a5)
 
 
-def testis_equal_set() -> None:
+def test_is_equal_set() -> None:
     s1 = {1, 2, 3}
     s2 = {1, 2, 3}
     assert is_equal(s1, s2)
@@ -168,7 +168,7 @@ def testis_equal_set() -> None:
     assert not is_equal(s1, s3)
 
 
-def testis_equal_list_and_tuple() -> None:
+def test_is_equal_list_and_tuple() -> None:
     assert not is_equal([1, 2, 3], (1, 2, 3))
     assert is_equal([1, 2, 3], [1, 2, 3])
     assert not is_equal([1, 2, 3], [1, 2, 4])
@@ -176,13 +176,13 @@ def testis_equal_list_and_tuple() -> None:
     assert not is_equal([1], [1, 2])
 
 
-def testis_equal_float() -> None:
+def test_is_equal_float() -> None:
     assert is_equal(1.0, 1.0)
     assert is_equal(1.0, 1.0000000001)
     assert not is_equal(1.0, 1.1)
 
 
-def testis_equal_custom_object() -> None:
+def test_is_equal_custom_object() -> None:
     obj1 = CustomObject(1)
     obj2 = CustomObject(1)
     assert is_equal(obj1, obj2)
@@ -191,14 +191,14 @@ def testis_equal_custom_object() -> None:
     assert not is_equal(obj1, obj3)
 
 
-def testis_equal_iterable() -> None:
+def test_is_equal_iterable() -> None:
     assert is_equal([1, 2, 3], [1, 2, 3])
     assert not is_equal([1, 2, 3], [1, 2, 4])
     assert is_equal((1, 2, 3), (1, 2, 3))
     assert not is_equal((1, 2, 3), (1, 2, 4))
 
 
-def testis_equal_other_types() -> None:
+def test_is_equal_other_types() -> None:
     assert is_equal(1, 1)
     assert not is_equal(1, 2)
     assert is_equal("abc", "abc")


### PR DESCRIPTION
Hey @basnijholt, I just realized that you've already implemented the `_utils._is_equal` functions which also compares more intricate datatypes that are not / should not be compared with just `__eq__`. I thought I could make this function public and use it in the comparsion of default values (#856) function to have less situations where it fails to compare default values.