### PR TITLE
BUG: Fix path resolution and add legacy format support for RunInfo.load

### DIFF
--- a/pipefunc/map/_run_info.py
+++ b/pipefunc/map/_run_info.py
@@ -174,24 +174,30 @@ class RunInfo:
         data = asdict(self)
         del data["inputs"]  # Cannot serialize inputs
         del data["defaults"]  # or defaults
-        data["input_paths"] = {k: str(v) for k, v in self.input_paths.items()}
+        # Here .relative_to to lstrip(run_folder) prefix for both input_paths and defaults_path
+        # We used to *not* do this in versions <=0.86.0, see _legacy_fix
+        data["input_paths"] = {
+            k: str(v.relative_to(self.run_folder)) for k, v in self.input_paths.items()
+        }
         data["all_output_names"] = sorted(data["all_output_names"])
         dicts_with_tuples = ["shapes", "shape_masks", "resolved_shapes"]
         if isinstance(self.storage, dict):
             dicts_with_tuples.append("storage")
         for key in dicts_with_tuples:
             data[key] = {_maybe_tuple_to_str(k): v for k, v in data[key].items()}
-        data["run_folder"] = str(data["run_folder"])
-        data["defaults_path"] = str(self.defaults_path)
+        data["run_folder"] = str(data["run_folder"].absolute())
+        data["defaults_path"] = str(self.defaults_path.relative_to(self.run_folder))
         with path.open("w") as f:
             json.dump(data, f, indent=4)
 
     @classmethod
     def load(cls: type[RunInfo], run_folder: str | Path) -> RunInfo:
-        path = cls.path(run_folder)
+        path = cls.path(run_folder)  # run_info.json
+        run_folder_abs = path.absolute().parent
         with path.open() as f:
             data = json.load(f)
-        data["input_paths"] = {k: Path(v) for k, v in data["input_paths"].items()}
+        _legacy_fix(data, run_folder_abs)
+        data["input_paths"] = {k: run_folder_abs / v for k, v in data["input_paths"].items()}
         data["all_output_names"] = set(data["all_output_names"])
         if isinstance(data["storage"], dict):
             data["storage"] = {_maybe_str_to_tuple(k): v for k, v in data["storage"].items()}
@@ -202,9 +208,9 @@ class RunInfo:
                 k: tuple(v) if isinstance(v, list) else v
                 for k, v in data["internal_shapes"].items()
             }
-        data["run_folder"] = Path(data["run_folder"])
-        data["inputs"] = {k: load(Path(v)) for k, v in data.pop("input_paths").items()}
-        data["defaults"] = load(Path(data.pop("defaults_path")))
+        data["run_folder"] = run_folder_abs
+        data["inputs"] = {k: load(v) for k, v in data.pop("input_paths").items()}
+        data["defaults"] = load(run_folder_abs / data.pop("defaults_path"))
         return cls(**data)
 
     @staticmethod
@@ -253,6 +259,45 @@ class RunInfo:
                     internal[name] = internal_shape_from_mask(new_shape, self.shape_masks[name])
         if has_updated:
             self.dump()
+
+
+def _legacy_fix(data: dict, run_folder: Path) -> None:
+    """Fix legacy format where paths included run_folder prefix.
+
+    Legacy format (<=v0.86.0):
+    - run_folder: "foo/my_run_folder"
+    - input_paths: {"x": "foo/my_run_folder/inputs/x.cloudpickle"}
+    - defaults_path: "foo/my_run_folder/defaults/defaults.cloudpickle"
+
+    New format (>v0.86.0):
+    - run_folder: /absolute/path/to/foo/my_run_folder
+    - input_paths: {"x": "inputs/x.cloudpickle"}
+    - defaults_path: "defaults/defaults.cloudpickle"
+
+    Parameters
+    ----------
+    data
+        RunInfo data dict (modified in place)
+    run_folder
+        Original run_folder path
+
+    """
+    stored_run_folder = data["run_folder"]
+
+    # Detect legacy: check if paths start with stored run_folder
+    is_legacy = data["defaults_path"].startswith(stored_run_folder)
+
+    if not is_legacy:
+        return
+
+    # Fix paths: strip the stored run_folder prefix
+    stored_prefix = Path(stored_run_folder)
+
+    data["run_folder"] = str(run_folder.resolve())
+    data["defaults_path"] = str(Path(data["defaults_path"]).relative_to(stored_prefix))
+    data["input_paths"] = {
+        k: str(Path(v).relative_to(stored_prefix)) for k, v in data["input_paths"].items()
+    }
 
 
 # Max size for inputs in bytes (100 kB)

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -16,7 +16,7 @@ from pipefunc._utils import prod
 from pipefunc.map._load import load_all_outputs, load_dataframe, load_outputs, load_xarray_dataset
 from pipefunc.map._mapspec import trace_dependencies
 from pipefunc.map._prepare import _reduced_axes
-from pipefunc.map._run_info import RunInfo, map_shapes
+from pipefunc.map._run_info import RunInfo, _legacy_fix, map_shapes
 from pipefunc.map._storage_array._base import StorageBase, storage_registry
 from pipefunc.map._storage_array._dict import SharedMemoryDictArray
 from pipefunc.map._storage_array._file import FileArray
@@ -2050,3 +2050,62 @@ def test_load_dataframe_with_list_of_tuples_output(tmp_path: Path) -> None:
     assert isinstance(final_array, np.ndarray)
     assert final_array.shape == (3, 3)
     np.testing.assert_array_equal(final_array, np.array(expected, dtype=object))
+
+
+def test_legacy_fix(tmp_path: Path) -> None:
+    """Test that _legacy_fix correctly converts legacy format paths to new format."""
+
+    # Test 1: Legacy format (<=v0.86.0)
+    legacy_data: dict[str, Any] = {
+        "run_folder": "adaptive_1d/run_folder_0.0",
+        "defaults_path": "adaptive_1d/run_folder_0.0/defaults/defaults.cloudpickle",
+        "input_paths": {
+            "x": "adaptive_1d/run_folder_0.0/inputs/x.cloudpickle",
+            "d": "adaptive_1d/run_folder_0.0/inputs/d.cloudpickle",
+            "c": "adaptive_1d/run_folder_0.0/inputs/c.cloudpickle",
+        },
+    }
+
+    run_folder = tmp_path / "adaptive_1d" / "run_folder_0.0"
+    _legacy_fix(legacy_data, run_folder)
+
+    assert legacy_data["run_folder"] == str(run_folder.resolve())
+    assert legacy_data["defaults_path"] == "defaults/defaults.cloudpickle"
+    assert legacy_data["input_paths"] == {
+        "x": "inputs/x.cloudpickle",
+        "d": "inputs/d.cloudpickle",
+        "c": "inputs/c.cloudpickle",
+    }
+
+    # Test 2: New format (>v0.86.0) should remain unchanged
+    new_data: dict[str, Any] = {
+        "run_folder": str(run_folder.resolve()),
+        "defaults_path": "defaults/defaults.cloudpickle",
+        "input_paths": {
+            "x": "inputs/x.cloudpickle",
+            "d": "inputs/d.cloudpickle",
+        },
+    }
+
+    new_data_copy = new_data.copy()
+    _legacy_fix(new_data, run_folder)
+
+    # Should be unchanged (except run_folder might be different object)
+    assert new_data["defaults_path"] == new_data_copy["defaults_path"]
+    assert new_data["input_paths"] == new_data_copy["input_paths"]
+
+    # Test 3: Different run_folder structure
+    legacy_data_2: dict[str, Any] = {
+        "run_folder": "foo/bar/my_run",
+        "defaults_path": "foo/bar/my_run/defaults/defaults.cloudpickle",
+        "input_paths": {
+            "a": "foo/bar/my_run/inputs/a.cloudpickle",
+        },
+    }
+
+    run_folder_2 = tmp_path / "foo" / "bar" / "my_run"
+    _legacy_fix(legacy_data_2, run_folder_2)
+
+    assert legacy_data_2["run_folder"] == str(run_folder_2.resolve())
+    assert legacy_data_2["defaults_path"] == "defaults/defaults.cloudpickle"
+    assert legacy_data_2["input_paths"]["a"] == "inputs/a.cloudpickle"


### PR DESCRIPTION
Changes `RunInfo` to store paths relative to `run_folder` for portability. Adds `_legacy_fix()` to handle data from versions <=0.86.0 where paths included the `run_folder` prefix.

When running e.g., `pipeline.map(inputs, run_folder="foo/my_run_folder")`:

New format (>v0.86.0):
- `run_folder: /absolute/path/to/run_folder`
- `input_paths: {"x": "inputs/x.cloudpickle"}`
- `defaults_path: "defaults/defaults.cloudpickle"`

Legacy format (<=v0.86.0):
- `run_folder: "foo/my_run_folder"`
- `input_paths: {"x": "foo/my_run_folder/inputs/x.cloudpickle"}`
- `defaults_path: "foo/my_run_folder/defaults/defaults.cloudpickle"`

This enables loading `run_folders` from different working directories while maintaining backward compatibility with existing data.