### PR TITLE
BUG: Mutating returned results leaks into cached copy reused by Pipeline.run

### DIFF
--- a/docs/source/concepts/caching.md
+++ b/docs/source/concepts/caching.md
@@ -181,6 +181,7 @@ pipeline.cache.clear()
 - When using `pipeline.map` with `parallel=True`, the cache itself will be serialized, so one must use a cache that supports shared memory, such as {class}`~pipefunc.cache.LRUCache` with `shared=True` or a disk cache like {class}`~pipefunc.cache.DiskCache`.
 - The {func}`pipefunc.cache.to_hashable` function is used to attempt to ensure that input values are hashable, which is a requirement for storing results in a cache.
 - This function works for many common types but is not guaranteed to work for all types.
+- Cached values are isolated from mutations: the in-memory caches store and return deep copies (shared caches achieve the same via (de)serialization), so mutating a returned result does not corrupt the cache entry. If your results are large and you never mutate them, you can opt out of the copy overhead with e.g. ``LRUCache(shared=False, copy=False)`` or ``SimpleCache(copy=False)``.
 
 By understanding and utilizing `pipefunc`'s caching mechanisms effectively, you can significantly improve the performance of your pipelines, especially when dealing with computationally expensive functions or large datasets.
 

--- a/pipefunc/cache.py
+++ b/pipefunc/cache.py
@@ -12,6 +12,7 @@ import sys
 import time
 import warnings
 from contextlib import nullcontext, suppress
+from copy import deepcopy
 from multiprocessing import Manager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -21,6 +22,25 @@ import cloudpickle
 if TYPE_CHECKING:
     from collections.abc import Callable, Hashable, Iterable
     from multiprocessing.managers import DictProxy, ListProxy, SyncManager
+
+
+def _try_deepcopy(value: Any) -> Any:
+    """Deep copy ``value``, falling back to the original object if copying fails.
+
+    Caches that keep values in regular (non-shared) memory return the *same*
+    object on every hit. Without a copy, mutating a returned value (or the
+    value after it was stored) silently corrupts the cache entry.
+    """
+    try:
+        return deepcopy(value)
+    except Exception as e:  # noqa: BLE001  # pragma: no cover
+        warnings.warn(
+            f"Cannot deepcopy cached value of type `{type(value).__name__}` ({e!r});"
+            " using the original object instead. Mutating it will affect the cache.",
+            UserWarning,
+            stacklevel=3,
+        )
+        return value
 
 
 class _CacheBase(abc.ABC):
@@ -67,6 +87,12 @@ class HybridCache(_CacheBase):
         Use cloudpickle for storing the data in memory if using shared memory.
     shared
         Whether the cache should be shared between multiple processes.
+    copy
+        Whether to store and return deep copies of the values when the cache is
+        not shared (a shared cache already (de)serializes the values, which has
+        the same effect). This prevents mutations of returned values (or of the
+        original object after storing) from leaking into the cache. Set to
+        ``False`` to avoid the copy overhead for large values that are never mutated.
 
     """
 
@@ -78,6 +104,7 @@ class HybridCache(_CacheBase):
         *,
         allow_cloudpickle: bool = True,
         shared: bool = True,
+        copy: bool = True,
     ) -> None:
         """Initialize the HybridCache instance."""
         if shared:
@@ -96,6 +123,7 @@ class HybridCache(_CacheBase):
         self.duration_weight: float = duration_weight
         self.shared: bool = shared
         self._allow_cloudpickle: bool = allow_cloudpickle
+        self._copy: bool = copy
 
     @property
     def cache(self) -> dict[Hashable, Any]:
@@ -147,6 +175,9 @@ class HybridCache(_CacheBase):
         value = self._cache_dict[key]
         if self._allow_cloudpickle and self.shared:
             value = cloudpickle.loads(value)
+        elif not self.shared and self._copy:
+            # A shared cache returns a fresh copy via the manager proxy already.
+            value = _try_deepcopy(value)
         return value
 
     def put(self, key: Hashable, value: Any, duration: float) -> None:  # type: ignore[override]
@@ -167,6 +198,8 @@ class HybridCache(_CacheBase):
         """
         if self._allow_cloudpickle and self.shared:
             value = cloudpickle.dumps(value)
+        elif not self.shared and self._copy:
+            value = _try_deepcopy(value)
         with self._cache_lock:
             if len(self._cache_dict) >= self.max_size:
                 self._expire()
@@ -282,6 +315,12 @@ class LRUCache(_CacheBase):
         Use cloudpickle for storing the data in memory if using shared memory.
     shared
         Whether the cache should be shared between multiple processes.
+    copy
+        Whether to store and return deep copies of the values when the cache is
+        not shared (a shared cache already (de)serializes the values, which has
+        the same effect). This prevents mutations of returned values (or of the
+        original object after storing) from leaking into the cache. Set to
+        ``False`` to avoid the copy overhead for large values that are never mutated.
 
     """
 
@@ -291,11 +330,13 @@ class LRUCache(_CacheBase):
         max_size: int = 128,
         allow_cloudpickle: bool = True,
         shared: bool = True,
+        copy: bool = True,
     ) -> None:
         """Initialize the cache."""
         self.max_size = max_size
         self.shared = shared
         self._allow_cloudpickle = allow_cloudpickle
+        self._copy = copy
         if max_size == 0:  # pragma: no cover
             msg = "max_size must be greater than 0"
             raise ValueError(msg)
@@ -320,12 +361,17 @@ class LRUCache(_CacheBase):
             self._cache_queue.append(key)
         if self._allow_cloudpickle and self.shared:
             return cloudpickle.loads(value)
+        if not self.shared and self._copy:
+            # A shared cache returns a fresh copy via the manager proxy already.
+            return _try_deepcopy(value)
         return value
 
     def put(self, key: Hashable, value: Any) -> None:
         """Insert a key value pair into the cache."""
         if self._allow_cloudpickle and self.shared:
             value = cloudpickle.dumps(value)
+        elif not self.shared and self._copy:
+            value = _try_deepcopy(value)
         with self._cache_lock:
             self._cache_dict[key] = value
             cache_size = len(self._cache_queue)
@@ -386,19 +432,31 @@ class LRUCache(_CacheBase):
 
 
 class SimpleCache(_CacheBase):
-    """A simple cache without any eviction strategy."""
+    """A simple cache without any eviction strategy.
 
-    def __init__(self) -> None:
+    Parameters
+    ----------
+    copy
+        Whether to store and return deep copies of the values. This prevents
+        mutations of returned values (or of the original object after storing)
+        from leaking into the cache. Set to ``False`` to avoid the copy overhead
+        for large values that are never mutated.
+
+    """
+
+    def __init__(self, *, copy: bool = True) -> None:
         """Initialize the cache."""
         self._cache_dict: dict[Hashable, Any] = {}
+        self._copy = copy
 
     def get(self, key: Hashable) -> Any:
         """Get a value from the cache by key."""
-        return self._cache_dict.get(key)
+        value = self._cache_dict.get(key)
+        return _try_deepcopy(value) if self._copy else value
 
     def put(self, key: Hashable, value: Any) -> None:
         """Insert a key value pair into the cache."""
-        self._cache_dict[key] = value
+        self._cache_dict[key] = _try_deepcopy(value) if self._copy else value
 
     def __contains__(self, key: Hashable) -> bool:
         """Check if a key is present in the cache."""

--- a/tests/map/test_cache_result_dict.py
+++ b/tests/map/test_cache_result_dict.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pipefunc import Pipeline, pipefunc
+
+if TYPE_CHECKING:
+    from pipefunc.map._result import ResultDict
+
+
+def test_cached_resultdict_reuses_mutable_instance() -> None:
+    """Mutating returned results leaks into cached copy reused by Pipeline.run."""
+
+    @pipefunc(output_name="values")
+    def identity(x: list[int]) -> list[int]:
+        return x
+
+    inner = Pipeline(
+        [
+            (identity, "x[i] -> values[i]"),
+        ],
+        cache_type="simple",
+    )
+
+    @pipefunc(output_name="results", cache=True)
+    def run_inner(x: list[int]) -> ResultDict:
+        return inner.map({"x": x}, parallel=False)
+
+    outer = Pipeline([run_inner], cache_type="simple")
+
+    first = outer.run("results", kwargs={"x": [1, 2, 3]})
+    assert first["values"].output.tolist() == [1, 2, 3]
+
+    # User mutates the returned ResultDict in place.
+    first["values"].output[1] = 999
+
+    second = outer.run("results", kwargs={"x": [1, 2, 3]})
+
+    # Fails on current implementation because the cached ResultDict is reused.
+    assert second["values"].output[1] == 2

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -547,3 +547,53 @@ def test_pickling_and_deepcopy_disk(shared: bool, with_lru: bool) -> None:
         cache.put("key3", "value3")
         assert "key3" in cache
         assert "key3" in copied_cache
+
+
+@pytest.mark.parametrize("cache_type", ["lru", "hybrid", "simple"])
+def test_cache_returns_independent_copies(cache_type: str) -> None:
+    cache: LRUCache | HybridCache | SimpleCache
+    if cache_type == "lru":
+        cache = LRUCache(shared=False)
+    elif cache_type == "hybrid":
+        cache = HybridCache(shared=False)
+    else:
+        cache = SimpleCache()
+
+    value = {"a": [1, 2, 3]}
+    args = ("k", value, 1.0) if cache_type == "hybrid" else ("k", value)
+    cache.put(*args)
+
+    # Mutating the original object after `put` does not affect the cache
+    value["a"].append(4)
+    assert cache.get("k") == {"a": [1, 2, 3]}
+
+    # Mutating a returned value does not affect later hits
+    first = cache.get("k")
+    assert first is not None
+    first["a"][0] = 999
+    assert cache.get("k") == {"a": [1, 2, 3]}
+
+
+@pytest.mark.parametrize("cache_type", ["lru", "hybrid", "simple"])
+def test_cache_copy_false_aliases(cache_type: str) -> None:
+    cache: LRUCache | HybridCache | SimpleCache
+    if cache_type == "lru":
+        cache = LRUCache(shared=False, copy=False)
+    elif cache_type == "hybrid":
+        cache = HybridCache(shared=False, copy=False)
+    else:
+        cache = SimpleCache(copy=False)
+
+    value = {"a": [1, 2, 3]}
+    args = ("k", value, 1.0) if cache_type == "hybrid" else ("k", value)
+    cache.put(*args)
+    assert cache.get("k") is value
+
+
+def test_disk_cache_lru_returns_independent_copies(tmp_path: Path) -> None:
+    cache = DiskCache(cache_dir=str(tmp_path), with_lru_cache=True, lru_shared=False)
+    cache.put("k", {"a": [1, 2, 3]})
+    first = cache.get("k")
+    assert first is not None
+    first["a"][0] = 999
+    assert cache.get("k") == {"a": [1, 2, 3]}


### PR DESCRIPTION
Fixes the bug reported by @MitchellAcoustics in https://github.com/pipefunc/pipefunc/pull/854#issuecomment-3391504848: a `ResultDict` (or any mutable result) returned by a cached function is stored in the cache *by reference*, so mutating the returned object — by a downstream function in the same run, or by the user afterwards — silently corrupts the cache entry. The next `pipeline.run` then returns the mutated object instead of the original result (e.g. `ErrorSnapshot`s stripped to `nan`), making repeated runs non-idempotent.

## The fix

The in-memory caches now store and return **deep copies**:

- `SimpleCache`, `LRUCache(shared=False)`, and `HybridCache(shared=False)` deep-copy values on `put` (snapshots the entry before anything can mutate it) **and** on `get` (so a consumer of a cache hit cannot corrupt the entry for the next hit). Both sides are required: copy-on-get alone cannot fix this bug, because the object returned to the caller *is* the stored entry.
- Shared caches (`shared=True`, the default) were never affected — they already isolate values via the cloudpickle/manager-proxy round-trip. `DiskCache`'s disk path also already isolates via pickling; its in-memory LRU layer inherits the fix.
- Opt out with `copy=False` (e.g. `LRUCache(shared=False, copy=False)`) for large values that are never mutated. Values that cannot be deep-copied fall back to the original object with a warning.
- Documented in the caching concept page.

## Performance

Copies are made only for the non-shared in-memory caches, once per `put` and once per hit. `deepcopy` is cheaper than the cloudpickle round-trip the default shared path already pays, and by definition cheaper than the recomputation the cache avoids. CodSpeed includes a cached-pipeline benchmark (`test_calling_pipeline_directly_with_cache`) which will quantify it.

## Verification

- The repro test from this PR (`tests/map/test_cache_result_dict.py`) now passes.
- New unit tests: put-then-mutate-original, get-then-mutate-returned, and `copy=False` aliasing opt-out for all three in-memory caches, plus `DiskCache`'s LRU layer.
- Full suite: 1412 passed; `pre-commit run --all-files` clean.

Addresses the caching pain point of #902. The separate notebook-staleness issue (cache keys don't include the function body, so editing a function returns stale cached results) is intentionally **not** part of this PR.
