### PR TITLE
TST: Skip SLURM tests on systems without /bin/bash

### DIFF
--- a/tests/map/test_adaptive_slurm_executor.py
+++ b/tests/map/test_adaptive_slurm_executor.py
@@ -5,6 +5,7 @@ import shutil
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Literal
 from unittest import mock
@@ -21,9 +22,9 @@ from pipefunc.map._storage_array._file import FileArray
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
-has_slurm = shutil.which("srun") is not None
+bash_path = Path("/bin/bash")
+has_slurm = shutil.which("srun") is not None and bash_path.exists()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- treat SLURM as unavailable when the interpreter path /bin/bash is missing
- prevents pytest from timing out on NixOS where SLURM job scripts fail immediately

## Testing
- uv run pytest -n auto