### PR TITLE
ENH: Expose original func as `PipeFunc.__call__` 

### DIFF
--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -1016,7 +1016,7 @@ class PipeFunc(Generic[P, R]):
 def pipefunc(
     output_name: OUTPUT_TYPE,
     *,
-    output_picker: Callable[[R, str], Any] | None = None,
+    output_picker: Callable[[Any, str], Any] | None = None,
     renames: dict[str, str] | None = None,
     defaults: dict[str, Any] | None = None,
     bound: dict[str, Any] | None = None,

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -2589,9 +2589,9 @@ def _update_all_results(
 
 def _execute_func(func: PipeFunc, func_args: dict[str, Any], lazy: bool) -> Any:
     if lazy:
-        return _LazyFunction(func, kwargs=func_args)
+        return _LazyFunction(func.run, kwargs=func_args)
     try:
-        return func(**func_args)
+        return func.run(**func_args)
     except Exception as e:
         handle_pipefunc_error(e, func, func_args)
         # handle_pipefunc_error raises but mypy doesn't know that

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -626,7 +626,7 @@ def _run_iteration(
 ) -> Any:
     def compute_fn() -> Any:
         try:
-            return func(**selected)
+            return func.run(**selected)
         except Exception as e:
             if not in_executor:
                 # If we are in the executor, we need to handle the error in `_result`
@@ -1074,7 +1074,7 @@ def _execute_single(
 
     def compute_fn() -> Any:
         try:
-            return func(**kwargs)
+            return func.run(**kwargs)
         except Exception as e:
             handle_pipefunc_error(e, func, kwargs)
             # handle_pipefunc_error raises but mypy doesn't know that

--- a/tests/test_pipefunc.py
+++ b/tests/test_pipefunc.py
@@ -106,7 +106,7 @@ def test_update_defaults_and_renames_and_bound() -> None:
     assert f.defaults == {"a1": 42, "b": 2}
 
     # Call function with updated defaults
-    assert f(a1=3) == 5
+    assert f.run(a1=3) == 5
 
     # Overwrite defaults
     f.update_defaults({"a1": 1, "b": 3}, overwrite=True)
@@ -114,9 +114,9 @@ def test_update_defaults_and_renames_and_bound() -> None:
     assert f.parameters == ("a1", "b")
 
     # Call function with new defaults
-    assert f(a1=2) == 5
-    assert f() == 4
-    assert f(a1=2, b=3) == 5
+    assert f.run(a1=2) == 5
+    assert f.run() == 4
+    assert f.run(a1=2, b=3) == 5
 
     # Update renames
     assert f.renames == {"a": "a1"}
@@ -125,28 +125,28 @@ def test_update_defaults_and_renames_and_bound() -> None:
     assert f.parameters == ("a2", "b")
 
     # Call function with updated renames
-    assert f(a2=4) == 7
-    assert f(b=0) == 1
+    assert f.run(a2=4) == 7
+    assert f.run(b=0) == 1
 
     # Overwrite renames
     f.update_renames({"a": "a3"}, overwrite=True, update_from="original")
     assert f.parameters == ("a3", "b")
 
     # Call function with new renames
-    assert f(a3=1) == 4
+    assert f.run(a3=1) == 4
 
     assert f.defaults == {"a3": 1, "b": 3}  # need to reset defaults before updating bound
     f.update_defaults({}, overwrite=True)
     f.update_bound({"a3": "yolo", "b": "swag"})
-    assert f(a3=88, b=1) == "yoloswag"
+    assert f.run(a3=88, b=1) == "yoloswag"
     assert f.bound == {"a3": "yolo", "b": "swag"}
     f.update_renames({"a": "a4"}, update_from="original")
     assert f.bound == {"a4": "yolo", "b": "swag"}
     f.update_bound({}, overwrite=True)
-    assert f(a4=88, b=1) == 89
+    assert f.run(a4=88, b=1) == 89
 
     f.update_renames({"a4": "a5"}, update_from="current")
-    assert f(a5=88, b=1) == 89
+    assert f.run(a5=88, b=1) == 89
     f.update_renames({"b": "b1"}, update_from="current")
     assert f.renames == {"a": "a5", "b": "b1"}
 
@@ -408,16 +408,16 @@ def test_nested_func_renames_defaults_and_bound() -> None:
     nf.update_renames({"a": "a1", "b": "b1"}, update_from="original")
     assert nf.defaults == {"b1": 99}
     assert nf.renames == {"a": "a1", "b": "b1"}
-    assert nf(a1=1, b1=2) == 3
-    assert nf(a1=1) == 100
+    assert nf.run(a1=1, b1=2) == 3
+    assert nf.run(a1=1) == 100
     nf.update_defaults({"b1": 2, "a1": 2})
-    assert nf() == 4
+    assert nf.run() == 4
     assert nf.renames == {"a": "a1", "b": "b1"}
     assert nf.defaults == {"b1": 2, "a1": 2}
     # Reset defaults to update bound
     nf.update_defaults({}, overwrite=True)
     nf.update_bound({"a1": "a", "b1": "b"})
-    assert nf(a1=3, b1=4) == "ab"  # will ignore the input values now
+    assert nf.run(a1=3, b1=4) == "ab"  # will ignore the input values now
 
 
 def test_nested_pipefunc_with_resources() -> None:
@@ -485,9 +485,9 @@ def test_pipefunc_scope() -> None:
 
     scope = "x"
     f.update_scope(scope, "*")
-    assert f(x={"a": 1, "b": 1}) == 2
-    assert f(**{"x.a": 1, "x.b": 1}) == 2
-    assert f(**{"x.b": 1, "x": {"a": 1}}) == 2
+    assert f.run(x={"a": 1, "b": 1}) == 2
+    assert f.run(**{"x.a": 1, "x.b": 1}) == 2
+    assert f.run(**{"x.b": 1, "x": {"a": 1}}) == 2
 
 
 def test_set_pipefunc_scope_on_init() -> None:
@@ -499,11 +499,11 @@ def test_set_pipefunc_scope_on_init() -> None:
     assert f.parameter_scopes == {"x"}
     assert f.renames == {"a": "x.a", "b": "x.b", "c": "x.c"}
     assert str(f.mapspec) == "x.a[i] -> x.c[i]"
-    assert f(x={"a": 1, "b": 1}) == 2
+    assert f.run(x={"a": 1, "b": 1}) == 2
     f.update_scope(None, "*", "*")
     assert f.unscoped_parameters == ("a", "b")
     assert f.parameters == ("a", "b")
-    assert f(a=1, b=1) == 2
+    assert f.run(a=1, b=1) == 2
 
 
 def test_incorrect_resources_variable():
@@ -589,7 +589,7 @@ def test_error_snapshot(tmp_path: Path) -> None:
         raise ValueError(msg)
 
     with pytest.raises(ValueError, match="This is a test error"):
-        f(a=1, b=2)
+        f.run(a=1, b=2)
     snap = f.error_snapshot
     assert snap is not None
     assert isinstance(snap, ErrorSnapshot)
@@ -632,11 +632,11 @@ def test_defaults_dataclass_factory() -> None:
 
     pf = PipeFunc(TestClass, "container")
     assert pf.defaults["x0"] == [1, 2, 3]
-    assert pf() == TestClass(x0=[1, 2, 3], y0=100)
+    assert pf.run() == TestClass(x0=[1, 2, 3], y0=100)
 
     pf2 = PipeFunc(TestClass, "container", defaults={"x0": [4, 5, 6]})
     assert pf2.defaults["x0"] == [4, 5, 6]
-    assert pf2() == TestClass(x0=[4, 5, 6], y0=100)
+    assert pf2.run() == TestClass(x0=[4, 5, 6], y0=100)
 
 
 def test_default_and_bound() -> None:
@@ -674,13 +674,13 @@ def test_default_with_positional_args() -> None:
     def f(a, b=1):
         return a, b
 
-    assert f(1, 2) == (1, 2)
+    assert f.run(1, 2) == (1, 2)
     with pytest.raises(ValueError, match="Multiple values provided for parameter `a`"):
-        f(1, 2, a=2)
+        f.run(1, 2, a=2)
 
     f.update_renames({"a": "x.a", "b": "x.b"}, update_from="original")
-    assert f(1) == (1, 1)
-    assert f(**{"x.a": 1, "x.b": 2}) == (1, 2)
+    assert f.run(1) == (1, 1)
+    assert f.run(**{"x.a": 1, "x.b": 2}) == (1, 2)
 
 
 def test_nested_pipefunc_function_name() -> None:
@@ -706,20 +706,20 @@ def test_nested_pipefunc_renames() -> None:
     nf = NestedPipeFunc([PipeFunc(f, "f"), PipeFunc(g, "g")], renames={"f": "f1"})
     assert nf.renames == {"f": "f1"}
     nf.copy()
-    assert nf(a=1, b=2) == (3, 3)
+    assert nf.run(a=1, b=2) == (3, 3)
 
     # Rename input
     nf = NestedPipeFunc([PipeFunc(f, "f"), PipeFunc(g, "g")], renames={"a": "a1"})
     assert nf.renames == {"a": "a1"}
     nf.copy()
-    assert nf(a1=1, b=2) == (3, 3)
+    assert nf.run(a1=1, b=2) == (3, 3)
 
     # Rename both input and output (with scope)
     nf = NestedPipeFunc(
         [PipeFunc(f, "f"), PipeFunc(g, "g")],
         renames={"f": "x.f", "g": "x.g", "a": "x.a", "b": "x.b"},
     )
-    assert nf(**{"x.a": 1, "x.b": 2}) == (3, 3)
+    assert nf.run(**{"x.a": 1, "x.b": 2}) == (3, 3)
 
 
 def test_pipefunc_with_class_with___call__() -> None:
@@ -761,14 +761,14 @@ def test_wrapping_pipefunc_in_pipefunc() -> None:
     def test(input: Any) -> Any:  # noqa: A002
         return input
 
-    assert test(input2=1) == 1
+    assert test.run(input2=1) == 1
     test2 = PipeFunc(
         func=test,
         output_name="test2",
         renames={"input2": "input3"},
         mapspec="input3[i] -> test2[i]",
     )
-    assert test2(input3=1) == 1
+    assert test2.run(input3=1) == 1
 
 
 def test_wrapping_pipefunc_with_scope_in_pipefunc() -> None:
@@ -787,13 +787,13 @@ def test_wrapping_pipefunc_with_scope_in_pipefunc() -> None:
     assert parameter.name == "input"
     assert parameter.annotation == "int"
 
-    assert test(x={"input2": 1}) == 1
+    assert test.run(x={"input2": 1}) == 1
     test2 = PipeFunc(
         func=test,
         output_name="test2",
         renames={"x.input2": "x.input3"},
     )
-    assert test2(x={"input3": 1}) == 1
+    assert test2.run(x={"input3": 1}) == 1
 
     parameter = test2.original_parameters["x.input2"]
     assert isinstance(parameter, inspect.Parameter)
@@ -811,6 +811,6 @@ def test_renamed_inputs_error_snapshot():
         return a * 2
 
     with pytest.raises(ValueError, match="a cannot be negative"):
-        f(b=-1)  # This will raise an error
+        f.run(b=-1)  # This will raise an error
     with pytest.raises(ValueError, match="a cannot be negative"):
         f.error_snapshot.reproduce()

--- a/tests/test_pipefunc_annotations.py
+++ b/tests/test_pipefunc_annotations.py
@@ -34,7 +34,7 @@ def test_pipeline_function_annotations_multiple_outputs():
     assert add_func.parameter_annotations == {"x": int, "y": float}
     assert add_func.output_annotation == {"a_plus_one": int, "b_plus_one": float}
 
-    result = add_func(x=1, y=2.0)
+    result = add_func.run(x=1, y=2.0)
     assert result == (2, 3.0)
 
     assert str(add_func) == "add_numbers(...) → a_plus_one, b_plus_one"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -44,12 +44,12 @@ def test_pipeline_and_all_arg_combinations() -> None:
 
     fc = pipeline.func("c")
     fd = pipeline.func("d")
-    c = f1(a=2, b=3)
+    c = f1.run(a=2, b=3)
     assert fc(a=2, b=3) == c == fc(b=3, a=2) == 5
-    assert fd(a=2, b=3) == f2(b=3, c=c) == fd(b=3, c=c) == 15
+    assert fd(a=2, b=3) == f2.run(b=3, c=c) == fd(b=3, c=c) == 15
 
     fe = pipeline.func("e")
-    assert fe(a=2, b=3, x=1) == fe(a=2, b=3, d=15, x=1) == f3(c=c, d=15, x=1) == 75
+    assert fe(a=2, b=3, x=1) == fe(a=2, b=3, d=15, x=1) == f3.run(c=c, d=15, x=1) == 75
 
     all_args = pipeline.all_arg_combinations
     assert all_args == {
@@ -64,9 +64,9 @@ def test_pipeline_and_all_arg_combinations() -> None:
     }
 
     kw = {"a": 2, "b": 3, "x": 1}
-    kw["c"] = f1(a=kw["a"], b=kw["b"])
-    kw["d"] = f2(b=kw["b"], c=kw["c"])
-    kw["e"] = f3(c=kw["c"], d=kw["d"], x=kw["x"])
+    kw["c"] = f1.run(a=kw["a"], b=kw["b"])
+    kw["d"] = f2.run(b=kw["b"], c=kw["c"])
+    kw["e"] = f3.run(c=kw["c"], d=kw["d"], x=kw["x"])
     for params in all_args["e"]:
         _kw = {k: kw[k] for k in params}
         assert fe(**_kw) == kw["e"]
@@ -76,7 +76,7 @@ def test_pipeline_and_all_arg_combinations() -> None:
     assert f_nested.output_name == ("c", "d")
     assert f_nested.parameters == ("a", "b", "x")
     assert f_nested.defaults == {"x": 1}
-    assert f_nested(a=2, b=3) == (5, 15)
+    assert f_nested.run(a=2, b=3) == (5, 15)
     assert f_nested.renames == {}
     f_nested.update_renames({"a": "a1", "b": "b1"})
     assert f_nested.renames == {"a": "a1", "b": "b1"}
@@ -89,7 +89,7 @@ def test_pipeline_and_all_arg_combinations() -> None:
     assert f_nested.parameters == ("a2", "b2", "x")
     f_nested_copy = f_nested.copy()
     assert f_nested_copy.renames == f_nested.renames
-    assert f_nested_copy(a2=2, b2=3) == (5, 15)
+    assert f_nested_copy.run(a2=2, b2=3) == (5, 15)
     f_nested_copy.update_renames({}, overwrite=True)
     pipeline = Pipeline([f_nested_copy, f3])
     assert pipeline("e", a=2, b=3, x=1) == 75
@@ -121,12 +121,12 @@ def test_pipeline_and_all_arg_combinations_rename(f2):
 
     fc = pipeline.func("c")
     fd = pipeline.func("d")
-    c = f1(a=2, b=3)
+    c = f1.run(a=2, b=3)
     assert fc(a=2, b=3) == c == fc(b=3, a=2) == 5
-    assert fd(a=2, b=3, xx=1) == f2(b=3, c=c, xx=1) == fd(b=3, c=c, xx=1) == 15
+    assert fd(a=2, b=3, xx=1) == f2.run(b=3, c=c, xx=1) == fd(b=3, c=c, xx=1) == 15
 
     fe = pipeline.func("e")
-    assert fe(a=2, b=3, x=1, xx=1) == fe(a=2, b=3, d=15, x=1) == f3(c=c, d=15, x=1) == 75
+    assert fe(a=2, b=3, x=1, xx=1) == fe(a=2, b=3, d=15, x=1) == f3.run(c=c, d=15, x=1) == 75
 
     all_args = pipeline.all_arg_combinations
     assert all_args == {
@@ -524,9 +524,9 @@ def test_setting_defaults() -> None:
     assert f.parameters == ("a1", "b")
     assert f.defaults == {"b": 2}
     with pytest.raises(ValueError, match="Unexpected keyword arguments"):
-        f(a=0)
+        f.run(a=0)
 
-    assert f(a1=0) == 2
+    assert f.run(a1=0) == 2
 
     pipeline = Pipeline([f])
     assert pipeline("c", a1=0) == 2
@@ -546,8 +546,8 @@ def test_setting_defaults() -> None:
     def h(a="a", b="b"):
         return a, b
 
-    assert h() == ("b_new", "a_new")
-    assert h(a="aa", b="bb") == ("bb", "aa")
+    assert h.run() == ("b_new", "a_new")
+    assert h.run(a="aa", b="bb") == ("bb", "aa")
 
 
 def test_subpipeline() -> None:
@@ -771,7 +771,7 @@ def test_unhashable_bound() -> None:
     def f(a, b):
         return a, b
 
-    assert f(a=1) == (1, [])
+    assert f.run(a=1) == (1, [])
     pipeline = Pipeline([f])
     assert pipeline(a=1) == (1, [])
 

--- a/tests/test_pipeline_post_execution_hook.py
+++ b/tests/test_pipeline_post_execution_hook.py
@@ -12,7 +12,7 @@ def test_post_execution_hook() -> None:
         return a + b
 
     # Test direct function call
-    result = f(a=1, b=2)
+    result = f.run(a=1, b=2)
     assert result == 3
     assert len(hook_calls) == 1
     assert hook_calls[0] == ("c", 3, {"a": 1, "b": 2})

--- a/tests/test_pipeline_resources.py
+++ b/tests/test_pipeline_resources.py
@@ -54,13 +54,13 @@ def test_resources_variable():
     def f_c(a, b, resources):
         return resources.gpus
 
-    assert f_c(a=1, b=2) == 8
+    assert f_c.run(a=1, b=2) == 8
 
     pipeline = Pipeline([f_c])
     assert pipeline(a=1, b=2) == 8
 
     with pytest.raises(ValueError, match="Unexpected keyword arguments: `{'resources'}`"):
-        f_c(a=1, b=2, resources={"gpus": 4})
+        f_c.run(a=1, b=2, resources={"gpus": 4})
 
     with pytest.raises(ValueError, match="Unused keyword arguments: `resources`"):
         pipeline(a=1, b=2, resources={"gpus": 4})
@@ -160,7 +160,7 @@ def test_resources_func_with_variable() -> None:
         assert resources.cpus == a + b
         return a * b
 
-    result = j(a=2, b=3)
+    result = j.run(a=2, b=3)
     assert result == 6
 
     pipeline = Pipeline([j])

--- a/tests/test_pipeline_update.py
+++ b/tests/test_pipeline_update.py
@@ -31,7 +31,7 @@ def test_renaming_output_name() -> None:
 
 def test_update_pipeline_defaults() -> None:
     @pipefunc(output_name="c", defaults={"b": 1}, renames={"a": "a1"})
-    def f(a=42, b=69):
+    def f(a=42, b=69): # nice
         return a + b
 
     pipeline = Pipeline([f])
@@ -54,9 +54,9 @@ def test_update_pipeline_defaults() -> None:
     assert fp.parameters == ("a1", "b")
 
     # Call function with new defaults
-    assert fp(a1=2) == 5
-    assert fp() == 4
-    assert fp(a1=2, b=3) == 5
+    assert fp.run(a1=2) == 5
+    assert fp.run() == 4
+    assert fp.run(a1=2, b=3) == 5
 
     with pytest.raises(ValueError, match="Unused keyword arguments"):
         pipeline.update_defaults({"does_not_exist": 1})

--- a/tests/test_pipeline_update.py
+++ b/tests/test_pipeline_update.py
@@ -31,7 +31,7 @@ def test_renaming_output_name() -> None:
 
 def test_update_pipeline_defaults() -> None:
     @pipefunc(output_name="c", defaults={"b": 1}, renames={"a": "a1"})
-    def f(a=42, b=69): # nice
+    def f(a=42, b=69):  # nice
         return a + b
 
     pipeline = Pipeline([f])


### PR DESCRIPTION
Hi @basnijholt,
I gave it a shot to make the `@pipefunc` decorator less _invasive_, so that the annotations and docs are not removed, as mentioned in #902.

1. Exposing the annotations is quite easy if done correctly with `ParamSpec` for the input annotations and a normal `TypeVar` for the output annotation.

2. Exposing the documentation is a bit subtle and I currently see two different approaches here.

      In the case of 
      
      ```python
      @pipefunc("text")
      def function(a: int, b: str) -> str:
          """Desc.
          Args:
              a (int): _description_
              b (str): _description_
          Returns:
              str: _description_
          """
          return f"number {a}" + b
      
      
      function(1, "test")
      ```
      
      if the documentation should be readable when hovering the mouse over "function" on the last line, then the output annotation of the `pipefunc` function needs to be 
      
      ```python
      def pipefunc(...)-> Callable[[Callable[P, R]], Callable[P, R]]:
      ```
      
      but in that case you will get a type checking error for things like
      
      ```python
      function.update_bounds(...)   # Cannot access attribute "update_bounds" for class "FunctionType". Attribute "update_bounds" is unknown
      ```
      

      on the other hand, if we use the annotation 
      
      ```python
      def pipefunc(...)-> Callable[[Callable[P, R]], PipeFunc[P, R]]:
      ```
      
      then
      
      ```python
      function.update_scope(...) # Works as expected
      ```
      
      but then the documentation will only appear when the cursor is within the brackets (idk how to explain this, just check the demo.py file I pushed). I think that this would always be the standard behavior for PipeFuncs instantiated with `PipeFunc.__init__`.



I just wanted to push this draft for a quick review before diving into the subsequent changes that would still be needed so that this `PipeFunc` implementation also works within a `Pipeline`.