### PR TITLE
ENH: harden persisted run status error handling

### DIFF
--- a/docs/source/concepts/run-status.md
+++ b/docs/source/concepts/run-status.md
@@ -94,11 +94,20 @@ pipefunc-cli watch runs/my-run --interval 1 --timeout 300 --pretty
 This is useful when `map_async` is running in another process and you want to
 tail progress from a second terminal.
 
+```{important}
+Live heartbeat-based monitoring requires progress tracking to be enabled for the
+async run. In scripts or services, use `show_progress="headless"` with
+{meth}`~pipefunc.Pipeline.map_async` when you want `pipefunc-cli` to report live
+`running`, `failed`, or `cancelled` states without rendering a progress UI.
+Without a heartbeat file, `pipefunc-cli` falls back to filesystem heuristics.
+```
+
 ## How Status Is Determined
 
-For live async runs, `pipefunc` writes a `pipefunc_status.json` heartbeat. When
-that file is present and valid, `pipefunc-cli` prefers it because it can report
-live states such as `running`, `failed`, or `cancelled`.
+For async runs with progress tracking enabled, `pipefunc` writes a
+`pipefunc_status.json` heartbeat. When that file is present and valid,
+`pipefunc-cli` prefers it because it can report live states such as `running`,
+`failed`, or `cancelled`.
 
 When no heartbeat is available, status is inferred from the persisted run
 folder itself:

--- a/pipefunc/_run_status.py
+++ b/pipefunc/_run_status.py
@@ -40,37 +40,28 @@ def status_from_run_folder(
     """
     try:
         metadata, run_info_json, run_info_path = _load_run_metadata(run_folder)
-    except Exception as e:  # noqa: BLE001
+    except FileNotFoundError as e:
         return _error_status_result(run_folder=run_folder, error=e, status="missing")
+    except Exception as e:  # noqa: BLE001
+        return _error_status_result(run_folder=run_folder, error=e, status="error")
 
     heartbeat = load_run_status_heartbeat(run_folder)
     if heartbeat is not None:
-        return _status_from_heartbeat(
-            heartbeat,
-            run_folder=metadata["run_folder"],
-            disk_outputs=_progress_info_from_disk(metadata)[0] if include_outputs else None,
+        return _heartbeat_status_result(
+            heartbeat=heartbeat,
+            metadata=metadata,
             run_info_json=run_info_json,
             include_outputs=include_outputs,
             include_run_info=include_run_info,
         )
 
-    outputs, all_complete = _progress_info_from_disk(metadata)
-    progress_fraction = _overall_progress(outputs)
-    status = _derive_status(all_complete=all_complete, progress_fraction=progress_fraction)
-
-    result = _build_status_result(
-        run_folder=metadata["run_folder"],
-        status=status,
-        status_source="disk_heuristic",
-        outputs=outputs,
-        last_modified=_isoformat_timestamp(run_info_path.stat().st_mtime),
-        pipefunc_version=run_info_json.get("pipefunc_version", "unknown"),
+    return _disk_status_result(
+        metadata=metadata,
+        run_info_json=run_info_json,
+        run_info_path=run_info_path,
+        include_outputs=include_outputs,
+        include_run_info=include_run_info,
     )
-    if include_outputs:
-        result["outputs"] = outputs
-    if include_run_info:
-        result["run_info"] = run_info_json
-    return result
 
 
 def list_run_statuses(
@@ -110,10 +101,7 @@ def list_run_statuses(
         candidates = candidates[:max_runs]
 
     for _mtime, run_folder in candidates:
-        try:
-            status = status_from_run_folder(run_folder, include_outputs=False)
-        except Exception as e:  # noqa: BLE001
-            status = _error_status_result(run_folder=run_folder, error=e, status="error")
+        status = status_from_run_folder(run_folder, include_outputs=False)
         result["runs"].append(status)
 
     result["total_count"] = len(result["runs"])
@@ -242,6 +230,69 @@ def _status_from_heartbeat(
     else:
         result.pop("run_info", None)
     return add_heartbeat_staleness(result)
+
+
+def _heartbeat_status_result(
+    *,
+    heartbeat: dict[str, Any],
+    metadata: dict[str, Any],
+    run_info_json: dict[str, Any],
+    include_outputs: bool,
+    include_run_info: bool,
+) -> dict[str, Any]:
+    disk_outputs = None
+    output_metadata_error = None
+    if include_outputs:
+        try:
+            disk_outputs = _progress_info_from_disk(metadata)[0]
+        except Exception as e:  # noqa: BLE001
+            output_metadata_error = str(e)
+
+    try:
+        result = _status_from_heartbeat(
+            heartbeat,
+            run_folder=metadata["run_folder"],
+            disk_outputs=disk_outputs,
+            run_info_json=run_info_json,
+            include_outputs=include_outputs,
+            include_run_info=include_run_info,
+        )
+    except Exception as e:  # noqa: BLE001
+        return _error_status_result(run_folder=metadata["run_folder"], error=e, status="error")
+
+    if output_metadata_error is not None:
+        result["error"] = output_metadata_error
+    return result
+
+
+def _disk_status_result(
+    *,
+    metadata: dict[str, Any],
+    run_info_json: dict[str, Any],
+    run_info_path: Path,
+    include_outputs: bool,
+    include_run_info: bool,
+) -> dict[str, Any]:
+    try:
+        outputs, all_complete = _progress_info_from_disk(metadata)
+        progress_fraction = _overall_progress(outputs)
+        status = _derive_status(all_complete=all_complete, progress_fraction=progress_fraction)
+        result = _build_status_result(
+            run_folder=metadata["run_folder"],
+            status=status,
+            status_source="disk_heuristic",
+            outputs=outputs,
+            last_modified=_isoformat_timestamp(run_info_path.stat().st_mtime),
+            pipefunc_version=run_info_json.get("pipefunc_version", "unknown"),
+        )
+    except Exception as e:  # noqa: BLE001
+        return _error_status_result(run_folder=metadata["run_folder"], error=e, status="error")
+
+    if include_outputs:
+        result["outputs"] = outputs
+    if include_run_info:
+        result["run_info"] = run_info_json
+    return result
 
 
 def _merge_disk_output_metadata(

--- a/tests/test_run_status_cli.py
+++ b/tests/test_run_status_cli.py
@@ -630,6 +630,17 @@ def test_status_from_run_folder_corrupted_run_info_shapes(
     assert status["outputs"]["values"]["bytes"] > 0
 
 
+def test_status_from_run_folder_corrupted_run_info_json_returns_error(tmp_path: Path) -> None:
+    run_folder = tmp_path / "corrupt-run-info"
+    run_folder.mkdir()
+    (run_folder / "run_info.json").write_text("{")
+
+    status = status_from_run_folder(run_folder)
+
+    assert status["status"] == "error"
+    assert "Expecting property name enclosed in double quotes" in status["error"]
+
+
 def test_list_runs_handles_corrupted_storage_metadata(
     mapspec_pipeline: Pipeline,
     tmp_path: Path,
@@ -645,6 +656,55 @@ def test_list_runs_handles_corrupted_storage_metadata(
 
     assert statuses["runs"][0]["status"] == "error"
     assert "Cannot find storage class" in statuses["runs"][0]["error"]
+
+
+def test_status_from_run_folder_corrupted_storage_metadata_returns_error(
+    mapspec_pipeline: Pipeline,
+    tmp_path: Path,
+) -> None:
+    run_folder = tmp_path / "broken-storage-status"
+    mapspec_pipeline.map(inputs={"x": [1, 2, 3]}, run_folder=run_folder, parallel=False)
+
+    run_info_json = _load_run_info_json(run_folder)
+    run_info_json["storage"] = {}
+    _write_run_info_json(run_folder, run_info_json)
+
+    status = status_from_run_folder(run_folder)
+
+    assert status["status"] == "error"
+    assert "Cannot find storage class" in status["error"]
+
+
+@pytest.mark.asyncio
+async def test_status_from_run_folder_heartbeat_reports_output_metadata_error(
+    slow_pipeline: Pipeline,
+    tmp_path: Path,
+) -> None:
+    run_folder = tmp_path / "heartbeat-broken-storage"
+    executor = ThreadPoolExecutor(max_workers=1)
+    runner = slow_pipeline.map_async(
+        inputs={"x": list(range(6))},
+        run_folder=run_folder,
+        executor=executor,
+        display_widgets=False,
+    )
+    try:
+        await _wait_for_heartbeat_status(run_folder)
+
+        run_info_json = _load_run_info_json(run_folder)
+        run_info_json["storage"] = {}
+        _write_run_info_json(run_folder, run_info_json)
+
+        status = status_from_run_folder(run_folder)
+
+        assert status["status_source"] == "heartbeat"
+        assert status["status"] in {"pending", "running", "completed"}
+        assert "Cannot find storage class" in status["error"]
+        assert "values" in status["outputs"]
+        assert "function_name" in status["outputs"]["values"]
+    finally:
+        await runner.task
+        executor.shutdown(wait=True)
 
 
 def test_status_from_run_folder_invalid_heartbeat_falls_back_to_disk(
@@ -696,6 +756,22 @@ def test_status_from_run_folder_invalid_heartbeat_timestamp(
     assert status["status_source"] == "heartbeat"
     assert status["stale"] is False
     assert status["outputs"]["result"]["bytes"] > 0
+
+
+def test_status_from_run_folder_invalid_heartbeat_payload_returns_error(
+    simple_pipeline: Pipeline,
+    tmp_path: Path,
+) -> None:
+    run_folder = tmp_path / "invalid-heartbeat-payload"
+    simple_pipeline.map(inputs={"x": 1, "y": 2}, run_folder=run_folder, parallel=False)
+
+    heartbeat_path = run_folder / "pipefunc_status.json"
+    heartbeat_path.write_text(json.dumps(["not-a-mapping"]))
+
+    status = status_from_run_folder(run_folder)
+
+    assert status["status"] == "error"
+    assert "dictionary update sequence element" in status["error"]
 
 
 def test_list_run_statuses(completed_run_folder: Path) -> None:
@@ -834,3 +910,23 @@ def test_status_cli_missing_run_folder(capsys: pytest.CaptureFixture) -> None:
     assert code == 1
     assert payload["status"] == "missing"
     assert "error" in payload
+
+
+def test_status_cli_corrupted_storage_returns_json_error(
+    mapspec_pipeline: Pipeline,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    run_folder = tmp_path / "cli-broken-storage"
+    mapspec_pipeline.map(inputs={"x": [1, 2, 3]}, run_folder=run_folder, parallel=False)
+
+    run_info_json = _load_run_info_json(run_folder)
+    run_info_json["storage"] = {}
+    _write_run_info_json(run_folder, run_info_json)
+
+    code = main(["status", str(run_folder)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert code == 1
+    assert payload["status"] == "error"
+    assert "Cannot find storage class" in payload["error"]


### PR DESCRIPTION
## Summary
- return `status="error"` for broken persisted metadata instead of mislabeling it as missing
- make `status_from_run_folder()` and `pipefunc-cli status` return JSON errors instead of raising on malformed storage metadata
- keep heartbeat-backed status readable when disk output metadata cannot be merged, and cover the new paths with real run-folder tests

## Verification
- `uv run pytest tests/test_run_status_cli.py tests/test_mcp.py -q`
- `uv run pytest -n 0 --cov=pipefunc._run_status --cov=pipefunc._run_status_heartbeat --cov=pipefunc._run_status_cli --cov-report term-missing tests/test_run_status_cli.py`
- `uv run ruff check pipefunc/_run_status.py tests/test_run_status_cli.py`

## Notes
- `uv run mypy pipefunc/_run_status.py tests/test_run_status_cli.py` in the fresh worktree hit unrelated missing-stub baseline errors outside this change (`pipefunc/cache.py`, `pipefunc/_widgets/output_tabs.py`), so I did not use it as a gate for this follow-up PR.