### PR TITLE
ENH: clean up run status review findings

### DIFF
--- a/docs/source/concepts/run-status.md
+++ b/docs/source/concepts/run-status.md
@@ -13,9 +13,6 @@ kernelspec:
 
 # Persisted Run Inspection
 
-```{try-notebook}
-```
-
 ```{contents} ToC
 :depth: 2
 ```

--- a/pipefunc/map/_prepare.py
+++ b/pipefunc/map/_prepare.py
@@ -120,6 +120,9 @@ def _create_progress_tracker(
     if progress is not None:
         return progress
     if in_async and run_folder is not None and show_progress is not False:
+        # A headless tracker is needed so the heartbeat writer has a
+        # progress_dict to snapshot, even when the user didn't request a
+        # visible progress bar.
         return init_tracker(store, pipeline.sorted_functions, "headless", in_async)
     return None
 

--- a/tests/test_run_status_cli.py
+++ b/tests/test_run_status_cli.py
@@ -58,16 +58,6 @@ def slow_pipeline() -> Pipeline:
 
 
 @pytest.fixture
-def slow_scalar_pipeline() -> Pipeline:
-    @pipefunc(output_name="result")
-    def slow_increment(x: int) -> int:
-        time.sleep(0.05)
-        return x + 1
-
-    return Pipeline([slow_increment])
-
-
-@pytest.fixture
 def fast_scalar_pipeline() -> Pipeline:
     @pipefunc(output_name="result")
     def increment(x: int) -> int:


### PR DESCRIPTION
## Summary
Follow-up to #938 addressing review findings:

- Remove unused `slow_scalar_pipeline` test fixture (dead code)
- Remove `{try-notebook}` directive from `run-status.md` (page has no Python cells to execute)
- Add comment documenting why `_create_progress_tracker` implicitly creates a headless tracker for async runs (behavioral change needed for heartbeat support)

## Test plan
- [x] All 39 tests in `test_run_status_cli.py` pass
- [x] Pre-commit hooks pass (ruff, mypy, etc.)