### PR TITLE
BUG: Avoid unsafe fork in threaded process pools

### DIFF
--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -4,6 +4,8 @@ import asyncio
 import functools
 import itertools
 import math
+import multiprocessing
+import threading
 import time
 import warnings
 from collections.abc import Callable, Iterable, Sequence
@@ -1261,10 +1263,22 @@ def _maybe_executor(
     parallel: bool,
 ) -> Generator[dict[OUTPUT_TYPE, Executor] | None, None, None]:
     if executor is None and parallel:
-        with ProcessPoolExecutor() as new_executor:  # shuts down the executor after use
+        with _default_process_pool_executor() as new_executor:
             yield {"": new_executor}
     else:
         yield executor
+
+
+def _default_process_pool_executor() -> ProcessPoolExecutor:
+    """Create the default process pool without forking multithreaded parents."""
+    if threading.active_count() <= 1:
+        return ProcessPoolExecutor()
+    start_methods = multiprocessing.get_all_start_methods()
+    if "forkserver" in start_methods:
+        return ProcessPoolExecutor(mp_context=multiprocessing.get_context("forkserver"))
+    if "spawn" in start_methods:
+        return ProcessPoolExecutor(mp_context=multiprocessing.get_context("spawn"))
+    return ProcessPoolExecutor()
 
 
 @dataclass

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -1216,6 +1216,20 @@ def test_default_process_pool_executor_avoids_fork_when_threads_exist(monkeypatc
     finally:
         executor.shutdown(cancel_futures=True)
 
+    monkeypatch.setattr(_run.multiprocessing, "get_all_start_methods", lambda: ["spawn"])
+    executor = _run._default_process_pool_executor()
+    try:
+        assert executor._mp_context.get_start_method() == "spawn"
+    finally:
+        executor.shutdown(cancel_futures=True)
+
+    monkeypatch.setattr(_run.multiprocessing, "get_all_start_methods", list)
+    executor = _run._default_process_pool_executor()
+    try:
+        assert isinstance(executor, ProcessPoolExecutor)
+    finally:
+        executor.shutdown(cancel_futures=True)
+
 
 def test_fixed_indices(tmp_path: Path) -> None:
     @pipefunc(output_name="z", mapspec="x[i], y[i] -> z[i]")

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -1205,6 +1205,18 @@ def test_parallel():
     assert results["sum"].output == 14
 
 
+def test_default_process_pool_executor_avoids_fork_when_threads_exist(monkeypatch):
+    from pipefunc.map import _run
+
+    monkeypatch.setattr(_run.threading, "active_count", lambda: 2)
+
+    executor = _run._default_process_pool_executor()
+    try:
+        assert executor._mp_context.get_start_method() != "fork"
+    finally:
+        executor.shutdown(cancel_futures=True)
+
+
 def test_fixed_indices(tmp_path: Path) -> None:
     @pipefunc(output_name="z", mapspec="x[i], y[i] -> z[i]")
     def f(x: int, y: int) -> int:
@@ -1568,6 +1580,8 @@ def test_internal_shape_in_pipefunc(dim: int | Literal["?"]):
 
 @pytest.mark.parametrize("storage", ["dict", "zarr_memory"])
 def test_parallel_memory_storage(storage: str):
+    from pipefunc.map import _run
+
     if storage == "zarr_memory" and not has_zarr:
         pytest.skip("zarr not installed")
     if storage == "zarr_memory" and sys.version_info >= (3, 13):
@@ -1591,7 +1605,8 @@ def test_parallel_memory_storage(storage: str):
 
     pipeline = Pipeline([f, g, h, i])
     inputs = {"x": [1, 2, 3]}
-    r1 = pipeline.map(inputs, storage=storage, parallel=True, executor=ProcessPoolExecutor())
+    with _run._default_process_pool_executor() as executor:
+        r1 = pipeline.map(inputs, storage=storage, parallel=True, executor=executor)
     r2 = pipeline.map(inputs, storage=storage, parallel=True)
     assert r1["r"].output == r2["r"].output == 12
 

--- a/tests/test_run_status_cli.py
+++ b/tests/test_run_status_cli.py
@@ -221,12 +221,23 @@ async def test_status_from_run_folder_incomplete(slow_pipeline: Pipeline, tmp_pa
 
 @pytest.mark.asyncio
 async def test_status_from_run_folder_uses_heartbeat_by_default(
-    slow_pipeline: Pipeline,
     tmp_path: Path,
 ) -> None:
+    release = threading.Event()
+
+    @pipefunc(output_name="values", mapspec="x[i] -> values[i]")
+    def slow_square(x: float) -> float:
+        release.wait()
+        return x**2
+
+    @pipefunc(output_name="total")
+    def aggregate(values: Array[float]) -> float:
+        return float(sum(values))
+
+    pipeline = Pipeline([slow_square, aggregate])
     run_folder = tmp_path / "heartbeat"
     executor = ThreadPoolExecutor(max_workers=1)
-    runner = slow_pipeline.map_async(
+    runner = pipeline.map_async(
         inputs={"x": list(range(8))},
         run_folder=run_folder,
         executor=executor,
@@ -245,10 +256,11 @@ async def test_status_from_run_folder_uses_heartbeat_by_default(
 
         running_status = await _wait_for_status(
             run_folder,
-            predicate=lambda s: s["status"] == "running" and bool(s["active_functions"]),
+            predicate=lambda s: "slow_square" in s["active_functions"],
         )
         assert "slow_square" in running_status["active_functions"]
 
+        release.set()
         await runner.task
         final_status = status_from_run_folder(run_folder)
 
@@ -257,6 +269,9 @@ async def test_status_from_run_folder_uses_heartbeat_by_default(
         assert final_status["active_functions"] == []
         assert final_status["stale"] is False
     finally:
+        release.set()
+        if not runner.task.done():
+            await runner.task
         executor.shutdown(wait=True)
 
 


### PR DESCRIPTION
## Summary
- Avoid default process-pool `fork` when the parent process already has multiple threads, using `forkserver`/`spawn` where available.
- Make the heartbeat active-function test deterministic by blocking `slow_square` until observed.
- Reuse the safe process-pool factory in the memory-storage parallel test.

## Test Plan
- `uv run pytest tests/test_run_status_cli.py::test_status_from_run_folder_uses_heartbeat_by_default`
- `uv run pytest tests/map/test_map.py::test_default_process_pool_executor_avoids_fork_when_threads_exist`
- `uv run pytest 'tests/map/test_map.py::test_parallel_memory_storage[dict]'`\n- `uvx nox -e pytest_min_deps-3.13 -v`\n- `uvx nox -e pytest_all_deps-3.12 -v`\n- `uv run pre-commit run --all-files`