### PR TITLE
ENH: Make `output_name` optional in `Pipeline.run`

### DIFF
--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -553,7 +553,9 @@ class Pipeline:
         ----------
         __output_name__
             The identifier for the return value of the pipeline.
-            Is None by default, in which case the unique leaf node is used.
+            Is None by default, in which case the unique leaf node is used,
+            or all leaf nodes if there are multiple (returning a tuple of
+            their outputs).
             This parameter is positional-only and the strange name is used
             to avoid conflicts with the ``output_name`` argument that might be
             passed via ``kwargs``.
@@ -565,8 +567,6 @@ class Pipeline:
             The return value of the pipeline.
 
         """
-        if __output_name__ is None:
-            __output_name__ = self.unique_leaf_node.output_name
         return self.run(__output_name__, kwargs=kwargs)
 
     def _get_func_args(
@@ -665,6 +665,11 @@ class Pipeline:
         _update_all_results(func, r, output_name, all_results, self.lazy)
         return all_results[output_name]
 
+    def _default_output_name(self) -> OUTPUT_TYPE | list[OUTPUT_TYPE]:
+        """Return the output name(s) of the leaf node(s) of the pipeline graph."""
+        output_names = [f.output_name for f in self.leaf_nodes]
+        return output_names[0] if len(output_names) == 1 else output_names
+
     def _validate_run_output_name(
         self,
         kwargs: dict[str, Any],
@@ -694,7 +699,7 @@ class Pipeline:
 
     def run(
         self,
-        output_name: OUTPUT_TYPE | list[OUTPUT_TYPE],
+        output_name: OUTPUT_TYPE | list[OUTPUT_TYPE] | None = None,
         *,
         full_output: bool = False,
         kwargs: dict[str, Any],
@@ -706,7 +711,9 @@ class Pipeline:
         ----------
         output_name
             The identifier for the return value of the pipeline. Can be a single
-            output name or a list of output names.
+            output name or a list of output names. If ``None``, the output name
+            of the unique leaf node is used, or all leaf nodes if there are
+            multiple (returning a tuple of their outputs).
         full_output
             Whether to return the outputs of all function executions
             as a dictionary mapping function names to their return values.
@@ -726,6 +733,8 @@ class Pipeline:
             return values of the pipeline functions.
 
         """
+        if output_name is None:
+            output_name = self._default_output_name()
         self._validate_run_output_name(kwargs, output_name)
         self._validate_scoped_parameters(kwargs)
         flat_scope_kwargs = self._flatten_scopes(kwargs)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1149,6 +1149,57 @@ def test_run_multiple_outputs_list() -> None:
     )
 
 
+def test_run_default_output_name_unique_leaf() -> None:
+    @pipefunc(output_name="c")
+    def f(a, b):
+        return a + b
+
+    @pipefunc(output_name="d")
+    def g(c):
+        return 2 * c
+
+    pipeline = Pipeline([f, g])
+    assert pipeline.run(kwargs={"a": 1, "b": 2}) == 6
+    assert pipeline.run(kwargs={"a": 1, "b": 2}, full_output=True) == {
+        "a": 1,
+        "b": 2,
+        "c": 3,
+        "d": 6,
+    }
+
+
+def test_run_default_output_name_multiple_leaves() -> None:
+    @pipefunc(output_name="c")
+    def f(a, b):
+        return a + b
+
+    @pipefunc(output_name="d")
+    def g(c):
+        return 2 * c
+
+    @pipefunc(output_name="e")
+    def h(c):
+        return 3 * c
+
+    pipeline = Pipeline([f, g, h])
+    assert len(pipeline.leaf_nodes) == 2
+    assert pipeline.run(kwargs={"a": 1, "b": 2}) == (6, 9)
+    assert pipeline(a=1, b=2) == (6, 9)
+
+
+def test_run_default_output_name_multiple_outputs_leaf() -> None:
+    @pipefunc(output_name="c")
+    def f(a, b):
+        return a + b
+
+    @pipefunc(output_name=("d", "e"))
+    def g(c):
+        return 2 * c, 3 * c
+
+    pipeline = Pipeline([f, g])
+    assert pipeline.run(kwargs={"a": 1, "b": 2}) == (6, 9)
+
+
 def test_disjoint_pipefuncs() -> None:
     @pipefunc(output_name="c")
     def f(a, b):


### PR DESCRIPTION
## Summary

Addresses the first suggestion in #902: `pipeline.run` required an `output_name`, even when the pipeline has a unique leaf node, while `pipeline(...)` (i.e., `__call__`) did not.

- `Pipeline.run(output_name=None)` (now the default) resolves to the unique leaf node's output name, or to **all** leaf nodes when there are multiple, returning a tuple of their outputs (as requested in #902: *"just run the full pipeline, even without unique leaf nodes"*).
- `Pipeline.__call__` now delegates the `None` case to `run`, so `pipeline(a=1, b=2)` also works for pipelines with multiple leaf nodes instead of raising.

## Example

```python
@pipefunc(output_name="c")
def f(a, b):
    return a + b

@pipefunc(output_name="d")
def g(c):
    return 2 * c

pipeline = Pipeline([f, g])
pipeline.run(kwargs={"a": 1, "b": 2})  # 6, no output_name needed
```

## Verification

- New tests: unique leaf default, multiple-leaves default (tuple result, both via `run` and `__call__`), and a leaf with a multi-output `output_name` tuple.
- Full suite: 1396 passed, 11 skipped, 2 xfailed.
- `pre-commit` (ruff, mypy, etc.) passes.

Closes nothing on its own; part of #902.