### PR TITLE
ENH: Accept flexible `output_names` types in `map`, `map_async`, and `subpipeline`

### DIFF
--- a/docs/source/concepts/execution-and-parallelism.md
+++ b/docs/source/concepts/execution-and-parallelism.md
@@ -25,7 +25,7 @@ kernelspec:
 
 These methods are used to execute the pipeline but have different use cases:
 
-- `pipeline.run(output_name, kwargs)` is used to execute the pipeline as a function and is fully sequential. It allows going from any input arguments to any output arguments. It does **not** support map-reduce operations. Internally, it keeps all intermediate results in memory in a dictionary.
+- `pipeline.run(output_name, kwargs)` is used to execute the pipeline as a function and is fully sequential. The `output_name` is optional; if omitted, the unique leaf node is used, or all leaf nodes if there are multiple (returning a tuple). It allows going from any input arguments to any output arguments. It does **not** support map-reduce operations. Internally, it keeps all intermediate results in memory in a dictionary.
 - `pipeline.map(inputs, ...)` is used to execute the pipeline in parallel. It supports map-reduce operations and is optimized for parallel execution. Internally, it puts all intermediate results in a {class}`~pipefunc.map.StorageBase` (there are implementations for storing on disk or in memory).
 
 ```{note}
@@ -34,6 +34,8 @@ Internally, the `pipeline.run` method is called when using the pipeline as a fun
 - `pipeline.run(output_name, kwargs)`
 - `pipeline(output_name, **kwargs)`
 - `f = pipeline.func(output_name)` and then `f(**kwargs)`
+
+In all three, `output_name` may be omitted to use the leaf node(s) of the pipeline.
 
 ```
 
@@ -44,7 +46,7 @@ Here is a table summarizing the differences between `pipeline.run` and `pipeline
 | Execution mode                                         | Sequential                                                                       | Parallel (any {class}`~concurrent.futures.Executor` class) or sequential                                               |
 | Map-reduce support (via {class}`pipefunc.map.MapSpec`) | No                                                                               | Yes                                                                                                                    |
 | Input arguments                                        | Can provide _any_ input arguments for any function in the pipeline               | Requires the root arguments (use {class}`~pipefunc.Pipeline.subpipeline` to get a subgraph)                            |
-| Output arguments                                       | Can request the output of any function in the pipeline                           | Calculates _all_ function nodes in the entire pipeline (use {class}`~pipefunc.Pipeline.subpipeline` to get a subgraph) |
+| Output arguments                                       | Can request the output of any function in the pipeline                           | Calculates _all_ outputs by default; select specific ones with ``output_names=...``                                    |
 | Intermediate results storage                           | In-memory dictionary                                                             | Configurable storage ({class}`~pipefunc.map.StorageBase`), e.g., on disk, cloud, or in (shared-)memory                 |
 | Use case                                               | Executing the pipeline as a regular function, going from any input to any output | Optimized for parallel execution and map-reduce operations                                                             |
 | Calling syntax                                         | `pipeline.run(output_name, kwargs)` or `pipeline(output_name, **kwargs)`         | `pipeline.map(inputs, ...)`                                                                                            |

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -29,6 +29,7 @@ from pipefunc._utils import (
     assert_complete_kwargs,
     at_least_tuple,
     clear_cached_properties,
+    ensure_output_names_set,
     is_installed,
     is_running_in_ipynb,
     requires,
@@ -546,13 +547,20 @@ class Pipeline:
             # `clear_pipelines=False` to avoid infinite recursion
             f._clear_internal_cache(clear_pipelines=False)
 
-    def __call__(self, __output_name__: OUTPUT_TYPE | None = None, /, **kwargs: Any) -> Any:
+    def __call__(
+        self,
+        __output_name__: OUTPUT_TYPE | list[OUTPUT_TYPE] | None = None,
+        /,
+        **kwargs: Any,
+    ) -> Any:
         """Call the pipeline for a specific return value.
 
         Parameters
         ----------
         __output_name__
-            The identifier for the return value of the pipeline.
+            The identifier for the return value of the pipeline. Can be a single
+            output name or a list of output names (returning a tuple of their
+            outputs, like `Pipeline.run`).
             Is None by default, in which case the unique leaf node is used,
             or all leaf nodes if there are multiple (returning a tuple of
             their outputs).
@@ -773,7 +781,7 @@ class Pipeline:
         run_folder: str | Path | None = None,
         internal_shapes: UserShapeDict | None = None,
         *,
-        output_names: set[OUTPUT_TYPE] | None = None,
+        output_names: OUTPUT_TYPE | Iterable[OUTPUT_TYPE] | None = None,
         parallel: bool = True,
         executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
         chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int] | None] | None = None,
@@ -809,7 +817,10 @@ class Pipeline:
             The ``internal_shape`` can also be provided via the ``PipeFunc(..., internal_shape=...)`` argument.
             If a `PipeFunc` has an ``internal_shape`` argument *and* it is provided here, the provided value is used.
         output_names
-            The output(s) to calculate. If ``None``, the entire pipeline is run and all outputs are computed.
+            The output(s) to calculate. Can be a single output name (a ``tuple`` is the
+        output name of a function with multiple outputs, as in `Pipeline.run`) or a
+        collection of output names. If ``None``, the entire pipeline is run and all
+        outputs are computed.
         parallel
             Whether to run the functions in parallel. Is ignored if provided ``executor`` is not ``None``.
         executor
@@ -976,7 +987,7 @@ class Pipeline:
         run_folder: str | Path | None = None,
         internal_shapes: UserShapeDict | None = None,
         *,
-        output_names: set[OUTPUT_TYPE] | None = None,
+        output_names: OUTPUT_TYPE | Iterable[OUTPUT_TYPE] | None = None,
         executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
         chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int] | None] | None = None,
         storage: StorageType | None = None,
@@ -1015,7 +1026,10 @@ class Pipeline:
             The ``internal_shape`` can also be provided via the ``PipeFunc(..., internal_shape=...)`` argument.
             If a `PipeFunc` has an ``internal_shape`` argument *and* it is provided here, the provided value is used.
         output_names
-            The output(s) to calculate. If ``None``, the entire pipeline is run and all outputs are computed.
+            The output(s) to calculate. Can be a single output name (a ``tuple`` is the
+        output name of a function with multiple outputs, as in `Pipeline.run`) or a
+        collection of output names. If ``None``, the entire pipeline is run and all
+        outputs are computed.
         executor
             The executor to use for parallel execution. Can be specified as:
 
@@ -2256,7 +2270,7 @@ class Pipeline:
     def subpipeline(
         self,
         inputs: set[str] | None = None,
-        output_names: set[OUTPUT_TYPE] | None = None,
+        output_names: OUTPUT_TYPE | Iterable[OUTPUT_TYPE] | None = None,
     ) -> Pipeline:
         """Create a new pipeline containing only the nodes between the specified inputs and outputs.
 
@@ -2266,8 +2280,10 @@ class Pipeline:
             Set of input names to include in the subpipeline. If ``None``, all root nodes of the
             original pipeline will be used as inputs.
         output_names
-            Set of output names to include in the subpipeline. If ``None``, all leaf nodes of the
-            original pipeline will be used as outputs.
+            Output name(s) to include in the subpipeline. Can be a single output name
+            (a ``tuple`` is the output name of a function with multiple outputs, as in
+            `Pipeline.run`) or a collection of output names. If ``None``, all leaf nodes
+            of the original pipeline will be used as outputs.
 
         Returns
         -------
@@ -2307,6 +2323,7 @@ class Pipeline:
             msg = "At least one of `inputs` or `output_names` should be provided."
             raise ValueError(msg)
 
+        output_names = ensure_output_names_set(output_names)
         pipeline = self.copy()
 
         input_nodes: set[str | PipeFunc] = (

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -515,19 +515,27 @@ class Pipeline:
                 g.add_edge(_Resources(f.resources_variable, f.output_name), f)
         return g
 
-    def func(self, output_name: OUTPUT_TYPE | list[OUTPUT_TYPE]) -> _PipelineAsFunc:
+    def func(
+        self,
+        output_name: OUTPUT_TYPE | list[OUTPUT_TYPE] | None = None,
+    ) -> _PipelineAsFunc:
         """Create a composed function that can be called with keyword arguments.
 
         Parameters
         ----------
         output_name
-            The identifier for the return value of the composed function.
+            The identifier for the return value of the composed function. Can be a
+            single output name or a list of output names. If ``None``, the output
+            name of the unique leaf node is used, or all leaf nodes if there are
+            multiple (returning a tuple of their outputs).
 
         Returns
         -------
             The composed function that can be called with keyword arguments.
 
         """
+        if output_name is None:
+            output_name = self._default_output_name()
         key = tuple(output_name) if isinstance(output_name, list) else output_name
         if f := self._internal_cache.func.get(key):
             return f
@@ -2098,7 +2106,7 @@ class Pipeline:
 
     def nest_funcs(
         self,
-        output_names: set[OUTPUT_TYPE] | Literal["*"],
+        output_names: OUTPUT_TYPE | Iterable[OUTPUT_TYPE] | Literal["*"],
         new_output_name: OUTPUT_TYPE | None = None,
         function_name: str | None = None,
     ) -> NestedPipeFunc:
@@ -2107,8 +2115,10 @@ class Pipeline:
         Parameters
         ----------
         output_names
-            The output names to nest in a `NestedPipeFunc`. Can also be ``"*"`` to nest all functions
-            in the pipeline into a single `NestedPipeFunc`.
+            The output names to nest in a `NestedPipeFunc`. Can be a single output name
+            (a ``tuple`` is the output name of a function with multiple outputs, as in
+            `Pipeline.run`) or a collection of output names. Can also be ``"*"`` to nest
+            all functions in the pipeline into a single `NestedPipeFunc`.
         new_output_name
             The identifier for the output of the wrapped function. If ``None``, it is automatically
             constructed from all the output names of the `PipeFunc` instances. Must be a subset of
@@ -2125,7 +2135,9 @@ class Pipeline:
         if output_names == "*":
             funcs = self.functions.copy()
         else:
-            funcs = [self.output_to_func[output_name] for output_name in output_names]
+            names = ensure_output_names_set(output_names)
+            assert names is not None
+            funcs = [self.output_to_func[output_name] for output_name in names]
 
         for f in funcs:
             self.drop(f=f)

--- a/pipefunc/_pipeline/_base.py
+++ b/pipefunc/_pipeline/_base.py
@@ -818,9 +818,9 @@ class Pipeline:
             If a `PipeFunc` has an ``internal_shape`` argument *and* it is provided here, the provided value is used.
         output_names
             The output(s) to calculate. Can be a single output name (a ``tuple`` is the
-        output name of a function with multiple outputs, as in `Pipeline.run`) or a
-        collection of output names. If ``None``, the entire pipeline is run and all
-        outputs are computed.
+            output name of a function with multiple outputs, as in `Pipeline.run`) or a
+            collection of output names. If ``None``, the entire pipeline is run and all
+            outputs are computed.
         parallel
             Whether to run the functions in parallel. Is ignored if provided ``executor`` is not ``None``.
         executor
@@ -1027,9 +1027,9 @@ class Pipeline:
             If a `PipeFunc` has an ``internal_shape`` argument *and* it is provided here, the provided value is used.
         output_names
             The output(s) to calculate. Can be a single output name (a ``tuple`` is the
-        output name of a function with multiple outputs, as in `Pipeline.run`) or a
-        collection of output names. If ``None``, the entire pipeline is run and all
-        outputs are computed.
+            output name of a function with multiple outputs, as in `Pipeline.run`) or a
+            collection of output names. If ``None``, the entire pipeline is run and all
+            outputs are computed.
         executor
             The executor to use for parallel execution. Can be specified as:
 

--- a/pipefunc/_utils.py
+++ b/pipefunc/_utils.py
@@ -28,6 +28,24 @@ if TYPE_CHECKING:
     import pydantic
     from griffe import DocstringSection
 
+    from pipefunc._pipeline._types import OUTPUT_TYPE
+
+
+def ensure_output_names_set(
+    output_names: OUTPUT_TYPE | Iterable[OUTPUT_TYPE] | None,
+) -> set[OUTPUT_TYPE] | None:
+    """Normalize ``output_names`` to a set of output names.
+
+    A single ``str`` or ``tuple`` is treated as one output name (a ``tuple`` is
+    the output name of a function with multiple outputs, matching `Pipeline.run`);
+    any other iterable is treated as a collection of output names.
+    """
+    if output_names is None or isinstance(output_names, set):
+        return output_names
+    if isinstance(output_names, (str, tuple)):
+        return {output_names}
+    return set(output_names)
+
 
 def at_least_tuple(x: Any) -> tuple[Any, ...]:
     """Convert x to a tuple if it is not already a tuple."""

--- a/pipefunc/map/_load.py
+++ b/pipefunc/map/_load.py
@@ -77,7 +77,7 @@ def load_all_outputs(run_folder: str | Path) -> dict[str, Any]:
 
 
 def load_xarray_dataset(
-    *output_name: str,
+    *output_names: str,
     run_folder: str | Path,
     load_intermediate: bool = True,
 ) -> xr.Dataset:
@@ -85,7 +85,7 @@ def load_xarray_dataset(
 
     Parameters
     ----------
-    output_name
+    output_names
         The names of the outputs to load. If empty, all outputs are loaded.
     run_folder
         The folder where the pipeline run was stored.
@@ -105,13 +105,13 @@ def load_xarray_dataset(
         run_info.mapspecs,
         run_info.inputs,
         run_folder=run_folder,
-        output_names=output_name or None,  # type: ignore[arg-type]
+        output_names=output_names or None,  # type: ignore[arg-type]
         load_intermediate=load_intermediate,
     )
 
 
 def load_dataframe(
-    *output_name: str,
+    *output_names: str,
     run_folder: str | Path,
     load_intermediate: bool = True,
     backend: Literal["pandas", "polars"] = "pandas",
@@ -120,7 +120,7 @@ def load_dataframe(
 
     Parameters
     ----------
-    output_name
+    output_names
         The names of the outputs to load. If empty, all outputs are loaded.
     run_folder
         The folder where the pipeline run was stored.
@@ -137,7 +137,7 @@ def load_dataframe(
     from .xarray import xarray_dataset_to_dataframe
 
     ds = load_xarray_dataset(
-        *output_name,
+        *output_names,
         run_folder=run_folder,
         load_intermediate=load_intermediate,
     )

--- a/pipefunc/map/_prepare.py
+++ b/pipefunc/map/_prepare.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeVar
 
 from pipefunc._pipeline._pydantic import maybe_pydantic_model_to_dict
-from pipefunc._utils import at_least_tuple, is_running_in_ipynb
+from pipefunc._utils import at_least_tuple, ensure_output_names_set, is_running_in_ipynb
 
 from ._adaptive_scheduler_slurm_executor import validate_slurm_executor
 from ._mapspec import validate_consistent_axes
@@ -14,7 +14,7 @@ from ._result import ResultDict
 from ._run_info import RunInfo
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
     from concurrent.futures import Executor
     from pathlib import Path
 
@@ -47,7 +47,7 @@ def prepare_run(
     inputs: dict[str, Any] | pydantic.BaseModel,
     run_folder: str | Path | None,
     internal_shapes: UserShapeDict | None,
-    output_names: set[OUTPUT_TYPE] | None,
+    output_names: OUTPUT_TYPE | Iterable[OUTPUT_TYPE] | None,
     parallel: bool,
     executor: Executor | dict[OUTPUT_TYPE, Executor] | None,
     chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int] | None] | None,
@@ -67,6 +67,7 @@ def prepare_run(
     inputs = maybe_pydantic_model_to_dict(inputs)
     pipeline._validate_scoped_parameters(inputs)
     inputs = pipeline._flatten_scopes(inputs)
+    output_names = ensure_output_names_set(output_names)
     if auto_subpipeline or output_names is not None:
         pipeline = pipeline.subpipeline(set(inputs), output_names)
     executor = _expand_output_name_in_executor(pipeline, executor)

--- a/pipefunc/map/_run.py
+++ b/pipefunc/map/_run.py
@@ -80,7 +80,7 @@ def run_map(
     run_folder: str | Path | None = None,
     internal_shapes: UserShapeDict | None = None,
     *,
-    output_names: set[OUTPUT_TYPE] | None = None,
+    output_names: OUTPUT_TYPE | Iterable[OUTPUT_TYPE] | None = None,
     parallel: bool = True,
     executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
     chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int] | None] | None = None,
@@ -117,7 +117,10 @@ def run_map(
         The ``internal_shape`` can also be provided via the ``PipeFunc(..., internal_shape=...)`` argument.
         If a `PipeFunc` has an ``internal_shape`` argument *and* it is provided here, the provided value is used.
     output_names
-        The output(s) to calculate. If ``None``, the entire pipeline is run and all outputs are computed.
+        The output(s) to calculate. Can be a single output name (a ``tuple`` is the
+        output name of a function with multiple outputs, as in `Pipeline.run`) or a
+        collection of output names. If ``None``, the entire pipeline is run and all
+        outputs are computed.
     parallel
         Whether to run the functions in parallel. Is ignored if provided ``executor`` is not ``None``.
     executor
@@ -398,7 +401,7 @@ def run_map_async(
     run_folder: str | Path | None = None,
     internal_shapes: UserShapeDict | None = None,
     *,
-    output_names: set[OUTPUT_TYPE] | None = None,
+    output_names: OUTPUT_TYPE | Iterable[OUTPUT_TYPE] | None = None,
     executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
     chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int] | None] | None = None,
     storage: StorageType | None = None,
@@ -438,7 +441,10 @@ def run_map_async(
         The ``internal_shape`` can also be provided via the ``PipeFunc(..., internal_shape=...)`` argument.
         If a `PipeFunc` has an ``internal_shape`` argument *and* it is provided here, the provided value is used.
     output_names
-        The output(s) to calculate. If ``None``, the entire pipeline is run and all outputs are computed.
+        The output(s) to calculate. Can be a single output name (a ``tuple`` is the
+        output name of a function with multiple outputs, as in `Pipeline.run`) or a
+        collection of output names. If ``None``, the entire pipeline is run and all
+        outputs are computed.
     executor
         The executor to use for parallel execution. Can be specified as:
 

--- a/pipefunc/map/_run_eager.py
+++ b/pipefunc/map/_run_eager.py
@@ -21,7 +21,7 @@ from ._adaptive_scheduler_slurm_executor import maybe_finalize_slurm_executors
 from ._run_info import _handle_cleanup_deprecation
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
     from pathlib import Path
 
     import pydantic
@@ -45,7 +45,7 @@ def run_map_eager(
     run_folder: str | Path | None = None,
     internal_shapes: UserShapeDict | None = None,
     *,
-    output_names: set[OUTPUT_TYPE] | None = None,
+    output_names: OUTPUT_TYPE | Iterable[OUTPUT_TYPE] | None = None,
     parallel: bool = True,
     executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
     chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int] | None] | None = None,
@@ -86,7 +86,10 @@ def run_map_eager(
         The ``internal_shape`` can also be provided via the ``PipeFunc(..., internal_shape=...)`` argument.
         If a `PipeFunc` has an ``internal_shape`` argument *and* it is provided here, the provided value is used.
     output_names
-        The output(s) to calculate. If ``None``, the entire pipeline is run and all outputs are computed.
+        The output(s) to calculate. Can be a single output name (a ``tuple`` is the
+        output name of a function with multiple outputs, as in `Pipeline.run`) or a
+        collection of output names. If ``None``, the entire pipeline is run and all
+        outputs are computed.
     parallel
         Whether to run the functions in parallel. Is ignored if provided ``executor`` is not ``None``.
     executor

--- a/pipefunc/map/_run_eager_async.py
+++ b/pipefunc/map/_run_eager_async.py
@@ -21,7 +21,7 @@ from pipefunc.map._run_eager import (
 from ._run_info import _handle_cleanup_deprecation
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
     from concurrent.futures import Executor
     from pathlib import Path
 
@@ -46,7 +46,7 @@ def run_map_eager_async(
     run_folder: str | Path | None = None,
     internal_shapes: UserShapeDict | None = None,
     *,
-    output_names: set[OUTPUT_TYPE] | None = None,
+    output_names: OUTPUT_TYPE | Iterable[OUTPUT_TYPE] | None = None,
     executor: Executor | dict[OUTPUT_TYPE, Executor] | None = None,
     chunksizes: int | dict[OUTPUT_TYPE, int | Callable[[int], int] | None] | None = None,
     storage: StorageType | None = None,
@@ -91,7 +91,10 @@ def run_map_eager_async(
         The ``internal_shape`` can also be provided via the ``PipeFunc(..., internal_shape=...)`` argument.
         If a `PipeFunc` has an ``internal_shape`` argument *and* it is provided here, the provided value is used.
     output_names
-        The output(s) to calculate. If ``None``, the entire pipeline is run and all outputs are computed.
+        The output(s) to calculate. Can be a single output name (a ``tuple`` is the
+        output name of a function with multiple outputs, as in `Pipeline.run`) or a
+        collection of output names. If ``None``, the entire pipeline is run and all
+        outputs are computed.
     executor
         The executor to use for parallel execution. Can be specified as:
 

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -2273,3 +2273,41 @@ def test_pipeline_call_with_list_output_name() -> None:
 
     pipeline = Pipeline([f, g])
     assert pipeline(["c", "d"], a=1, b=2) == (3, 6)
+
+
+def test_nest_funcs_flexible_output_names() -> None:
+    def make_pipeline() -> Pipeline:
+        @pipefunc(output_name="c")
+        def f(a, b):
+            return a + b
+
+        @pipefunc(output_name="d")
+        def g(c):
+            return 2 * c
+
+        return Pipeline([f, g])
+
+    # list instead of set
+    pipeline = make_pipeline()
+    nf = pipeline.nest_funcs(["c", "d"], new_output_name="d")
+    assert nf.output_name == "d"
+    assert pipeline(a=1, b=2) == 6
+
+    # a single output name normalizes but still requires >= 2 functions to nest
+    pipeline = make_pipeline()
+    with pytest.raises(ValueError, match="at least two"):
+        pipeline.nest_funcs("c")
+
+
+def test_pipeline_func_default_output_name() -> None:
+    @pipefunc(output_name="c")
+    def f(a, b):
+        return a + b
+
+    @pipefunc(output_name="d")
+    def g(c):
+        return 2 * c
+
+    pipeline = Pipeline([f, g])
+    assert pipeline.func()(a=1, b=2) == 6
+    assert pipeline.func("c")(a=1, b=2) == 3

--- a/tests/map/test_map.py
+++ b/tests/map/test_map.py
@@ -2226,3 +2226,50 @@ def test_legacy_fix(tmp_path: Path) -> None:
     assert legacy_data_2["run_folder"] == str(run_folder_2.resolve())
     assert legacy_data_2["defaults_path"] == "defaults/defaults.cloudpickle"
     assert legacy_data_2["input_paths"]["a"] == "inputs/a.cloudpickle"
+
+
+def test_map_output_names_flexible_types(tmp_path: Path) -> None:
+    @pipefunc(output_name="y", mapspec="x[i] -> y[i]")
+    def f(x: int) -> int:
+        return x
+
+    @pipefunc(output_name=("z1", "z2"))
+    def g(y: Array[int]) -> tuple[int, int]:
+        return sum(y), len(y)
+
+    pipeline = Pipeline([f, g])
+    inputs = {"x": [1, 2, 3]}
+
+    # single output name as a bare string
+    r = pipeline.map(inputs, tmp_path, output_names="y", parallel=False, storage="dict")
+    assert len(r) == 1
+    assert r["y"].output.tolist() == [1, 2, 3]
+
+    # list of output names
+    r = pipeline.map(inputs, tmp_path, output_names=["y"], parallel=False, storage="dict")
+    assert len(r) == 1
+    assert r["y"].output.tolist() == [1, 2, 3]
+
+    # a tuple is a single (multiple-output) output name, like in `pipeline.run`
+    r = pipeline.map(inputs, output_names=("z1", "z2"), parallel=False, storage="dict")
+    assert r["z1"].output == 6
+    assert r["z2"].output == 3
+
+    # subpipeline accepts the same flexible types
+    partial = pipeline.subpipeline(output_names=["y"])
+    r = partial.map(inputs, tmp_path, parallel=False, storage="dict")
+    assert len(r) == 1
+    assert r["y"].output.tolist() == [1, 2, 3]
+
+
+def test_pipeline_call_with_list_output_name() -> None:
+    @pipefunc(output_name="c")
+    def f(a, b):
+        return a + b
+
+    @pipefunc(output_name="d")
+    def g(c):
+        return 2 * c
+
+    pipeline = Pipeline([f, g])
+    assert pipeline(["c", "d"], a=1, b=2) == (3, 6)


### PR DESCRIPTION
## Summary

Addresses the API-consistency pain point from #902 (related: #724): `pipeline.map` required `output_names` to be a `set`, while `pipeline.run` accepts a single name or a list, and `pipeline(...)` claimed to accept only a single name.

Now `output_names` in `Pipeline.map`, `Pipeline.map_async`, `Pipeline.subpipeline`, and the `run_map*` functions accepts:

- a bare string: `output_names="y"`
- a tuple, meaning **one** multiple-output name, consistent with `Pipeline.run`: `output_names=("z1", "z2")`
- any collection of names (list, set, ...): `output_names=["y", "z"]`

Normalization happens once in `pipefunc._utils.ensure_output_names_set`, applied in `prepare_run` (covers all four `run_map*` entry points) and in `subpipeline` (covers direct callers).

Additionally, `Pipeline.__call__` is now annotated to accept a list of output names — this already worked at runtime (it delegates to `run`) but type checkers rejected it: `pipeline(["c", "d"], a=1, b=2) == (3, 6)`.

Out of scope (deferred to #724 since it needs a deprecation cycle): unifying the parameter *names* `output_name` (`run`) vs `output_names` (`map`).

## Verification

- New tests: bare string, list, tuple-as-multi-output-name for `map`; list for `subpipeline`; list for `pipeline(...)`.
- Full suite: 1402 passed, 11 skipped, 2 xfailed.
- `pre-commit run --all-files` (ruff, mypy) passes.

Part of #902.