### PR TITLE
BUG: Include a fingerprint of the function body in cache keys

### DIFF
--- a/docs/source/concepts/caching.md
+++ b/docs/source/concepts/caching.md
@@ -85,7 +85,15 @@ You can specify the cache type using the `cache_type` parameter when creating a 
 
 ## Cache Keys
 
-The cache key is computed based on the input values of each {class}`~pipefunc.PipeFunc`.
+The cache key is computed based on the input values of each {class}`~pipefunc.PipeFunc` *and* a fingerprint of the function's implementation (a hash of its source code).
+This means that editing a function invalidates its cached results: redefining a function in a Jupyter notebook, or restarting a script after changing the code, will not return stale results from a persistent {class}`~pipefunc.cache.DiskCache`.
+
+```{note}
+The fingerprint covers the function's own source only.
+Editing a *helper function* that the cached function calls does not invalidate the cache; define a custom [`__pipefunc_hash__`](#the-__pipefunc_hash__-method) method if you need to include more context.
+For callables whose implementation cannot be fingerprinted (e.g., builtins), a warning is emitted and the cache key falls back to the output name only.
+```
+
 When using `pipeline.run` or calling the pipeline as a function, the cache key is computed based solely on the root arguments provided to the pipeline. This means that _*only*_ the root arguments need to be "hashable" (see [section](#handling-unhashable-objects) below) for caching to work.
 When using `pipeline.map`, the cache key is computed based on the input values of each {class}`~pipefunc.PipeFunc`. That means that _*all*_ arguments to each cached function must be "hashable" (see [section](#handling-unhashable-objects) below) for caching to work.
 
@@ -188,8 +196,8 @@ By understanding and utilizing `pipefunc`'s caching mechanisms effectively, you 
 ## Advanced: Caching Stateful Functions
 
 When caching stateful functions, you need to be careful about the cache key because the function's internal state can affect the result, even if the input arguments are the same.
-By default, `pipefunc` computes the [cache key](#cache-keys) based on the function's input arguments.
-However, this is insufficient for stateful functions where the internal state can change the output.
+By default, `pipefunc` computes the [cache key](#cache-keys) based on the function's input arguments and a fingerprint of its implementation.
+However, this is insufficient for stateful functions where the internal state can change the output (instance state is not part of the fingerprint).
 
 To address this, `pipefunc` provides a mechanism to customize how the cache key is generated for stateful functions using the special `__pipefunc_hash__` method.
 

--- a/pipefunc/_pipefunc.py
+++ b/pipefunc/_pipefunc.py
@@ -12,6 +12,7 @@ import contextlib
 import dataclasses
 import datetime
 import functools
+import hashlib
 import inspect
 import os
 import warnings
@@ -40,6 +41,7 @@ from pipefunc._utils import (
     is_pydantic_base_model,
     requires,
 )
+from pipefunc.cache import compute_function_hash
 from pipefunc.exceptions import ErrorSnapshot, PropagatedErrorSnapshot
 from pipefunc.lazy import evaluate_lazy
 from pipefunc.map._mapspec import ArraySpec, MapSpec, mapspec_axes
@@ -1025,11 +1027,26 @@ class PipeFunc(Generic[P, R]):
 
     @functools.cached_property
     def _cache_id(self) -> str:
-        """Return a unique identifier for the function used in cache keys."""
+        """Return a unique identifier for the function used in cache keys.
+
+        Includes a fingerprint of the function's implementation, so that
+        editing a function invalidates its cached results (e.g., when
+        redefining a function in a Jupyter notebook or when using a
+        persistent `~pipefunc.cache.DiskCache` across sessions).
+        """
         name = "-".join(at_least_tuple(self.output_name))
         if hasattr(self.func, "__pipefunc_hash__"):
             pipefunc_hash = self.func.__pipefunc_hash__()
             return f"{name}-{pipefunc_hash}"
+        if (function_hash := compute_function_hash(self.func)) is not None:
+            return f"{name}-{function_hash}"
+        warnings.warn(
+            f"Cannot fingerprint the implementation of `{self.__name__}` for the cache key;"
+            " cached results will not be invalidated when the function changes."
+            " Define a `__pipefunc_hash__` method on the callable to control this.",
+            UserWarning,
+            stacklevel=2,
+        )
         return name
 
 
@@ -1381,6 +1398,14 @@ class NestedPipeFunc(PipeFunc):
         f._bound = self._bound.copy()
         f.debug = self.debug
         return f
+
+    @functools.cached_property
+    def _cache_id(self) -> str:
+        """Return a unique identifier combining the nested functions' identifiers."""
+        name = "-".join(at_least_tuple(self.output_name))
+        combined = "|".join(f._cache_id for f in self.pipeline.sorted_functions)
+        digest = hashlib.sha256(combined.encode()).hexdigest()[:16]
+        return f"{name}-{digest}"
 
     def _combine_mapspecs(self) -> MapSpec | None:
         mapspecs = [f.mapspec for f in self.pipeline.functions]

--- a/pipefunc/cache.py
+++ b/pipefunc/cache.py
@@ -7,9 +7,11 @@ import array
 import collections
 import functools
 import hashlib
+import inspect
 import pickle
 import sys
 import time
+import types
 import warnings
 from contextlib import nullcontext, suppress
 from copy import deepcopy
@@ -22,6 +24,65 @@ import cloudpickle
 if TYPE_CHECKING:
     from collections.abc import Callable, Hashable, Iterable
     from multiprocessing.managers import DictProxy, ListProxy, SyncManager
+
+
+def compute_function_hash(func: Callable[..., Any]) -> str | None:
+    """Compute a short hash that fingerprints a callable's implementation.
+
+    Used in cache keys so that editing a function invalidates its cached
+    results (e.g., when redefining a function in a Jupyter notebook or when
+    using a persistent `DiskCache` across sessions).
+
+    The fingerprint is derived from, in order of preference:
+
+    1. The source code (``inspect.getsource``) of the callable.
+    2. The code object's bytecode, constants, and names (when no source is
+       available, e.g., for ``exec``-defined functions).
+    3. For callable class instances, the class is fingerprinted instead. Note
+       that instance *state* is not included; use ``__pipefunc_hash__`` for
+       stateful callables.
+
+    `functools.partial` objects are unwrapped and their bound arguments are
+    folded into the hash.
+
+    Returns ``None`` if no fingerprint can be computed (e.g., for builtins).
+    """
+    parts: list[str] = []
+    while isinstance(func, functools.partial):
+        parts.append(repr((func.args, sorted(func.keywords.items()))))
+        func = func.func
+    fingerprint = _fingerprint_callable(func)
+    if fingerprint is None:
+        return None
+    parts.append(fingerprint)
+    return hashlib.sha256("\n".join(parts).encode()).hexdigest()[:16]
+
+
+def _fingerprint_callable(obj: Any) -> str | None:
+    with suppress(Exception):
+        return inspect.getsource(obj)
+    code = getattr(obj, "__code__", None)
+    if code is not None:
+        return repr(
+            (
+                _code_repr(code),
+                getattr(obj, "__defaults__", None),
+                getattr(obj, "__kwdefaults__", None),
+            ),
+        )
+    if callable(obj) and not inspect.isroutine(obj) and not inspect.isclass(obj):
+        # A callable class instance: fingerprint its class.
+        return _fingerprint_callable(type(obj))
+    return None
+
+
+def _code_repr(code: types.CodeType) -> str:
+    # `repr` of a code object contains its memory address, so expand nested
+    # code objects (e.g., of inner functions and comprehensions) recursively.
+    consts = tuple(
+        _code_repr(c) if isinstance(c, types.CodeType) else repr(c) for c in code.co_consts
+    )
+    return repr((code.co_code, consts, code.co_names))
 
 
 def _try_deepcopy(value: Any) -> Any:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -597,3 +597,53 @@ def test_disk_cache_lru_returns_independent_copies(tmp_path: Path) -> None:
     assert first is not None
     first["a"][0] = 999
     assert cache.get("k") == {"a": [1, 2, 3]}
+
+
+def test_compute_function_hash() -> None:
+    from pipefunc.cache import compute_function_hash
+
+    def make(version: int):
+        if version == 1:
+
+            def f(a):
+                return a + 1
+
+        else:
+
+            def f(a):
+                return a + 2
+
+        return f
+
+    # identical source -> identical hash; different body -> different hash
+    assert compute_function_hash(make(1)) == compute_function_hash(make(1))
+    assert compute_function_hash(make(1)) != compute_function_hash(make(2))
+
+    # partial: bound arguments are folded into the hash
+    import functools
+
+    def g(a, b):
+        return a + b
+
+    assert compute_function_hash(functools.partial(g, b=1)) != compute_function_hash(
+        functools.partial(g, b=2),
+    )
+
+    # exec-defined function: no source available, falls back to the code object
+    ns1: dict = {}
+    ns2: dict = {}
+    exec("def h(x): return x + 1", ns1)  # noqa: S102
+    exec("def h(x): return x + 2", ns2)  # noqa: S102
+    h1, h2 = compute_function_hash(ns1["h"]), compute_function_hash(ns2["h"])
+    assert h1 is not None
+    assert h1 != h2
+
+    # builtins cannot be fingerprinted
+    assert compute_function_hash(len) is None
+
+    # callable class instances are fingerprinted via their class
+    class Adder:
+        def __call__(self, a):
+            return a + 1
+
+    assert compute_function_hash(Adder()) == compute_function_hash(Adder())

--- a/tests/test_lazy.py
+++ b/tests/test_lazy.py
@@ -130,9 +130,9 @@ def test_running_dag_pipeline():
 
     assert dag.mapping
     expected = [
-        ("c", (("a", 1), ("b", 2))),
-        ("d", (("a", 1), ("b", 2), ("x", 1))),
-        ("e", (("a", 1), ("b", 2), ("x", 1))),
+        (pipeline["c"]._cache_id, (("a", 1), ("b", 2))),
+        (pipeline["d"]._cache_id, (("a", 1), ("b", 2), ("x", 1))),
+        (pipeline["e"]._cache_id, (("a", 1), ("b", 2), ("x", 1))),
     ]
     assert list(dag.cache.cache) == expected
 

--- a/tests/test_nested_pipefunc.py
+++ b/tests/test_nested_pipefunc.py
@@ -774,8 +774,8 @@ def test_nested_pipefunc_preserve_cache_on_join() -> None:
     assert pipeline(a=1, b=2) == 18
     assert pipeline.cache is not None
     assert pipeline.cache.cache == {
-        ("c", (("a", 1), ("b", 2))): 3,
-        ("e", (("a", 1), ("b", 2))): 18,
+        (pipeline["c"]._cache_id, (("a", 1), ("b", 2))): 3,
+        (pipeline["e"]._cache_id, (("a", 1), ("b", 2))): 18,
     }
 
     # Check that the cache is preserved when combining pipelines and f+g is NestedPipeFunc
@@ -789,8 +789,8 @@ def test_nested_pipefunc_preserve_cache_on_join() -> None:
     assert pipeline["e"].cache
     assert pipeline(a=1, b=2) == 18
     assert pipeline.cache.cache == {
-        ("c-d", (("a", 1), ("b", 2))): (3, 6),
-        ("e", (("a", 1), ("b", 2))): 18,
+        (pipeline[("c", "d")]._cache_id, (("a", 1), ("b", 2))): (3, 6),
+        (pipeline["e"]._cache_id, (("a", 1), ("b", 2))): 18,
     }
 
 

--- a/tests/test_pipeline_cache.py
+++ b/tests/test_pipeline_cache.py
@@ -46,7 +46,7 @@ def test_tuple_outputs_with_cache() -> None:
     f = pipeline.func("i")
     r = f.call_full_output(a=1, b=2, x=3)["i"]
     assert r == f(a=1, b=2, x=3)
-    key = ("d-e", (("a", 1), ("b", 2), ("x", 3)))
+    key = (pipeline["d"]._cache_id, (("a", 1), ("b", 2), ("x", 3)))
     assert pipeline.cache is not None
     assert pipeline.cache.cache[key] == (6, 1)
 
@@ -135,18 +135,19 @@ def test_simple_cache() -> None:
     pipeline = Pipeline([f], cache_type="simple")
     assert pipeline("c", a=1, b=2) == (1, 2)
     assert pipeline.cache is not None
-    assert pipeline.cache.cache == {("c", (("a", 1), ("b", 2))): (1, 2)}
+    cid = pipeline["c"]._cache_id
+    assert pipeline.cache.cache == {(cid, (("a", 1), ("b", 2))): (1, 2)}
     pipeline.cache.clear()
     assert pipeline("c", a={"a": 1}, b=[2]) == ({"a": 1}, [2])
     m = _HASH_MARKER
     assert pipeline.cache.cache == {
-        ("c", (("a", (m, dict, (("a", 1),))), ("b", (m, list, (2,))))): ({"a": 1}, [2]),
+        (cid, (("a", (m, dict, (("a", 1),))), ("b", (m, list, (2,))))): ({"a": 1}, [2]),
     }
     assert len(pipeline.cache.cache) == 1
     pipeline.cache.clear()
     assert pipeline("c", a={"a"}, b=[2]) == ({"a"}, [2])
     assert pipeline.cache.cache == {
-        ("c", (("a", (m, set, ("a",))), ("b", (m, list, (2,))))): ({"a"}, [2]),
+        (cid, (("a", (m, set, ("a",))), ("b", (m, list, (2,))))): ({"a"}, [2]),
     }
     assert len(pipeline.cache.cache) == 1
 
@@ -184,8 +185,8 @@ def test_sharing_defaults() -> None:
     assert pipeline("d", a=1) == 3
     assert pipeline.cache is not None
     assert pipeline.cache.cache == {
-        ("c", (("a", 1), ("b", 1))): 2,
-        ("d", (("a", 1), ("b", 1))): 3,
+        (pipeline["c"]._cache_id, (("a", 1), ("b", 1))): 2,
+        (pipeline["d"]._cache_id, (("a", 1), ("b", 1))): 3,
     }
     # Call again, should use cache
     assert pipeline("d", a=1) == 3
@@ -288,3 +289,88 @@ def test_cache_with_custom__pipefunc_hash__() -> None:
     assert counter["call"] == 2
 
     assert pfunc._cache_id == "out-1"
+
+
+def _make_versioned_pipeline(version: int, cache_dir: Path) -> Pipeline:
+    if version == 1:
+
+        @pipefunc(output_name="c", cache=True)
+        def f(a):
+            return a + 1
+
+    else:
+
+        @pipefunc(output_name="c", cache=True)
+        def f(a):
+            return a + 2
+
+    return Pipeline(
+        [f],
+        cache_type="disk",
+        cache_kwargs={"cache_dir": cache_dir, "with_lru_cache": False},
+    )
+
+
+def test_disk_cache_invalidated_when_function_changes(tmp_path: Path) -> None:
+    """Editing a function must invalidate its cached results (issue #964)."""
+    p1 = _make_versioned_pipeline(1, tmp_path)
+    assert p1.run(kwargs={"a": 1}) == 2
+
+    # "Edit" the function (same name, same output_name, different body),
+    # as happens when re-running an edited notebook cell.
+    p2 = _make_versioned_pipeline(2, tmp_path)
+    assert p2.run(kwargs={"a": 1}) == 3  # stale cache would return 2
+
+    # The original version's entry is still valid.
+    p1b = _make_versioned_pipeline(1, tmp_path)
+    assert p1b.run(kwargs={"a": 1}) == 2
+
+
+def test_cache_id_stable_for_identical_source() -> None:
+    def make() -> PipeFunc:
+        @pipefunc(output_name="c", cache=True)
+        def f(a):
+            return a + 1
+
+        return f
+
+    assert make()._cache_id == make()._cache_id
+
+
+def test_cache_id_warns_when_unfingerprintable(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pipefunc import _pipefunc as pipefunc_module
+
+    monkeypatch.setattr(pipefunc_module, "compute_function_hash", lambda _: None)
+
+    @pipefunc(output_name="c", cache=True)
+    def f(a):
+        return a
+
+    with pytest.warns(UserWarning, match="Cannot fingerprint"):
+        assert f._cache_id == "c"
+
+
+def test_nested_pipefunc_cache_id_tracks_children() -> None:
+    from pipefunc import NestedPipeFunc
+
+    def make(version: int) -> NestedPipeFunc:
+        if version == 1:
+
+            @pipefunc(output_name="c")
+            def f(a):
+                return a + 1
+
+        else:
+
+            @pipefunc(output_name="c")
+            def f(a):
+                return a + 2
+
+        @pipefunc(output_name="d")
+        def g(c):
+            return 2 * c
+
+        return NestedPipeFunc([f, g], output_name="d")
+
+    assert make(1)._cache_id == make(1)._cache_id
+    assert make(1)._cache_id != make(2)._cache_id


### PR DESCRIPTION
Closes #964.

## Problem

The cache key contained only the `output_name` and the input values — never the function's implementation (`PipeFunc._cache_id` only included a hash when the callable defined `__pipefunc_hash__`). Consequences:

- Redefine a function in a Jupyter notebook → the pipeline silently returns the **stale** result of the old implementation.
- With a persistent `DiskCache`, stale results even survive kernel restarts and new sessions.

This was the remaining source of the caching confusion reported in #902 (the mutation half was fixed in #905).

## Solution

New `pipefunc.cache.compute_function_hash(func)` fingerprints a callable's implementation, and `PipeFunc._cache_id` appends it to the key. Resolution order:

1. `__pipefunc_hash__()` if defined — the existing explicit hook keeps highest priority (unchanged behavior).
2. `inspect.getsource(func)` — works for ordinary functions **including notebook cells** (IPython registers cell source in `linecache`).
3. Code-object fallback (`co_code`/`co_consts`/`co_names` + defaults, nested code objects expanded recursively since their `repr` contains memory addresses) for sourceless functions, e.g. `exec`-defined.
4. Last resort: previous name-only behavior **plus a `UserWarning`**, so silent staleness is never the failure mode (e.g. builtins).

`functools.partial` unwraps with its bound arguments folded in; callable class instances fingerprint their class (instance *state* is intentionally excluded — that is what `__pipefunc_hash__` is for); `NestedPipeFunc` combines its children's fingerprints.

Design notes: source-hash chosen over bytecode-primary (human-predictable invalidation, stable across Python versions, works in notebooks; same approach as `joblib.Memory`) and over cloudpickle-bytes hashing (module functions pickle by reference → no invalidation; pickled set ordering interacts with hash randomization → nondeterministic keys across sessions).

## Performance

Computed **once per `PipeFunc` instance** (`_cache_id` is a `cached_property`), lazily on first cache use: ~0.6 ms cold (file read), zero marginal cost per cache entry — per-entry key computation just reuses the precomputed string.

## Breaking-ish

Existing persistent `DiskCache` entries are invalidated once on upgrade (keys changed). Arguably the point of the fix.

## Limitation (documented)

Editing a *helper function* called by the cached function does not invalidate — same limitation as `joblib`; `__pipefunc_hash__` is the escape hatch. Documented in the caching concept page.

## Verification

- End-to-end repro: populate `DiskCache` with v1 of a function, redefine with a different body → recomputes; redefine with the identical body → still hits the cache.
- Unit tests: identical source → equal hash, body change → different hash, partial bound-args, `exec`-defined (code-object path), builtins → `None` + warning path, callable instances, `NestedPipeFunc` child edits propagate.
- Six existing exact-key test assertions updated to use `_cache_id` dynamically.
- Full suite: 1417 passed; `pre-commit run --all-files` and `doc-string-check` clean.