### PR TITLE
DOC: Add polars to docs/conda environments to fix Read the Docs build

### DIFF
--- a/.github/update-environment.py
+++ b/.github/update-environment.py
@@ -120,6 +120,7 @@ if __name__ == "__main__":
         "mcp",
         "pandas",
         "plotting",
+        "polars",
         "profiling",
         "pydantic",
         "rich",

--- a/docs/environment-sphinx.yml
+++ b/docs/environment-sphinx.yml
@@ -25,6 +25,8 @@ dependencies:
   # optional-dependencies: pandas
   - pandas
   - xarray
+  # optional-dependencies: polars
+  - polars
   # optional-dependencies: plotting
   - bokeh
   - python-graphviz

--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,8 @@ dependencies:
   # optional-dependencies: pandas
   - pandas
   - xarray
+  # optional-dependencies: polars
+  - polars
   # optional-dependencies: plotting
   - bokeh
   - python-graphviz


### PR DESCRIPTION
## Problem

The Read the Docs build for `latest` is failing since #966 landed:

```
ModuleNotFoundError: No module named 'polars'
```

The new polars example in `docs/source/concepts/function-io.md` executes during the docs build, but the generated `docs/environment-sphinx.yml` did not include the `polars` optional dependency group.

## Fix

Add `polars` to the `sections` tuple in `.github/update-environment.py` and regenerate `environment.yml` and `docs/environment-sphinx.yml`.