### PR TITLE
BUG: Preserve cache for map subpipelines

### DIFF
--- a/pipefunc/map/_prepare.py
+++ b/pipefunc/map/_prepare.py
@@ -69,7 +69,9 @@ def prepare_run(
     inputs = pipeline._flatten_scopes(inputs)
     output_names = ensure_output_names_set(output_names)
     if auto_subpipeline or output_names is not None:
-        pipeline = pipeline.subpipeline(set(inputs), output_names)
+        subpipeline = pipeline.subpipeline(set(inputs), output_names)
+        subpipeline.cache = pipeline.cache
+        pipeline = subpipeline
     executor = _expand_output_name_in_executor(pipeline, executor)
     validate_slurm_executor(executor, in_async)
     _validate_complete_inputs(pipeline, inputs)

--- a/tests/test_pipeline_cache.py
+++ b/tests/test_pipeline_cache.py
@@ -205,6 +205,48 @@ def test_sharing_defaults() -> None:
         assert calls == {"f": 2, "g": 2}
 
 
+@pytest.mark.parametrize(
+    ("output_names", "auto_subpipeline"),
+    [
+        pytest.param(["metric"], False, id="output_names"),
+        pytest.param(None, True, id="auto_subpipeline"),
+    ],
+)
+def test_map_subpipeline_shares_cache(
+    output_names: list[str] | None,
+    auto_subpipeline: bool,
+) -> None:
+    calls = {"simulate": 0, "metric": 0}
+
+    @pipefunc(output_name="sim", mapspec="x[i] -> sim[i]", cache=True)
+    def simulate(x):
+        calls["simulate"] += 1
+        return x * 10
+
+    @pipefunc(output_name="metric", mapspec="sim[i] -> metric[i]", cache=True)
+    def metric(sim):
+        calls["metric"] += 1
+        return sim + 1
+
+    pipeline = Pipeline(
+        [simulate, metric],
+        cache_type="hybrid",
+        cache_kwargs={"shared": False},
+    )
+    for _ in range(2):
+        pipeline.map(
+            {"x": [1, 2, 3]},
+            output_names=output_names,
+            auto_subpipeline=auto_subpipeline,
+            parallel=False,
+            storage="dict",
+        )
+
+    assert calls == {"simulate": 3, "metric": 3}
+    assert pipeline.cache is not None
+    assert len(pipeline.cache) == 6
+
+
 def test_autoset_cache() -> None:
     @pipefunc(output_name="y", cache=True)
     def f(a):


### PR DESCRIPTION
Closes #974.

## Problem

`Pipeline.map(..., output_names=...)` and `auto_subpipeline=True` create a temporary subpipeline for the run. `Pipeline.subpipeline()` constructs that copy with a fresh cache, so cached results are written to the temporary cache and discarded after each call. The parent pipeline therefore cannot reuse identical work across calls.

## Solution

Reuse the parent pipeline's cache on subpipelines created internally by `prepare_run`. This preserves cache entries across repeated map calls while leaving the public `Pipeline.subpipeline()` behavior unchanged.

Regression coverage verifies both `output_names` and `auto_subpipeline=True`: two identical calls execute each mapped function only once per input element and populate the parent cache.

## Verification

- `pytest tests/test_pipeline_cache.py --no-cov` — 19 passed
- Relevant map/subpipeline tests — 4 passed
- Ruff lint and format checks — passed
- Mypy on `pipefunc/map/_prepare.py` — passed
