### PR TITLE
MAINT: Restore NumPy 2.5 CI compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
       - id: mypy
         exclude: ipynb_filter.py|docs/source/conf.py|noxfile.py
         additional_dependencies:
+          - numpy<2.5  # Match mypy's configured Python 3.11 target
           - types-setuptools
           - pandas-stubs
           - types-psutil

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,7 +40,12 @@ def pytest_all_deps(session: nox.Session) -> None:
             # "mcp",  # because 'fastmcp' -> 'cryptography'
             # "zarr",  # because 'numcodecs' -> 'cryptography'
         ]
-        session.install(f".[test,{','.join(extras)}]")
+        requirements = [f".[test,{','.join(extras)}]"]
+        if session.python == "3.13t":
+            # These releases stopped publishing wheels for the experimental
+            # Python 3.13 free-threaded ABI. Avoid slow, fragile source builds.
+            requirements.extend(("nh3<0.3.2", "pillow<12.3", "scipy<1.18"))
+        session.install(*requirements)
     else:
         session.install(".[all,test]")
     session.run("pytest", *xdist)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -14,6 +14,7 @@ from typing import (
     TypeAlias,
     TypeVar,
     Union,
+    get_args,
     get_type_hints,
 )
 
@@ -68,8 +69,12 @@ def test_are_types_compatible_numpy():
     assert is_type_compatible(npt.NDArray, npt.NDArray[Any])
     assert is_type_compatible(npt.NDArray[Any], npt.NDArray[Any])
     assert is_type_compatible(npt.NDArray[np.int32], npt.NDArray[Any])
-    # npt.NDArray without arguments turns into numpy.ndarray[typing.Any, numpy.dtype[+_ScalarType_co]]
-    assert not is_type_compatible(npt.NDArray[Any], npt.NDArray)
+    if get_args(npt.NDArray):
+        # Before NumPy 2.5, bare NDArray retains an unresolved scalar type parameter.
+        assert not is_type_compatible(npt.NDArray[Any], npt.NDArray)
+    else:
+        # NumPy 2.5 defines NDArray with Any as the default scalar type.
+        assert is_type_compatible(npt.NDArray[Any], npt.NDArray)
 
 
 def test_are_types_compatible_standard_edge_cases():


### PR DESCRIPTION
## Problem

Recent dependency releases exposed three CI compatibility problems:

- The pre-commit mypy hook targets Python 3.11 but, because the hook itself runs on Python 3.14, resolved NumPy 2.5.1. NumPy 2.5 no longer supports Python 3.11 and its stubs use Python 3.12 `type` syntax, so mypy rejected the dependency before checking the project.
- NumPy 2.5 changed `numpy.typing.NDArray` to a generic alias with `Any` as its default scalar type. The existing test expected the pre-2.5 alias representation and failed throughout the uv minimal-dependency matrix.
- The latest nh3, Pillow, and SciPy releases no longer publish wheels for the experimental Python 3.13 free-threaded ABI. The all-dependency job consequently attempted unsupported or fragile source builds.

These failures currently affect unrelated PRs, including #971, #973, and #975.

## Solution

- Constrain only the mypy hook environment to `numpy<2.5`, matching mypy's configured Python 3.11 target. The package's runtime NumPy dependency remains unpinned and continues to test against NumPy 2.5.
- Make the `NDArray[Any]` compatibility assertion account for both the pre-2.5 parameterized alias and NumPy 2.5's defaulted generic alias.
- Keep only the Python 3.13t nox environment on the newest releases that still provide compatible wheels. Other Python environments remain unconstrained.

## Verification

- `pre-commit run --all-files` — passed
- Typing suite with locked NumPy 2.3.4 — 91 passed
- Typing suite with NumPy 2.5.1 — 91 passed
- Python 3.12 minimal environment with NumPy 2.5.1 — 1008 passed, 109 skipped, 2 xfailed
- Python 3.13t minimal environment with NumPy 2.5.1 — 1007 passed, 110 skipped, 2 xfailed
- Python 3.13t all-dependency environment — 1323 passed, 63 skipped, 2 xfailed
