### PR TITLE
ENH: Fix "ImportError: The 'graphviz_anywidget' package is required when Pipefunc[plotting] is installed"

### DIFF
--- a/pipefunc/_plotting.py
+++ b/pipefunc/_plotting.py
@@ -624,7 +624,7 @@ def visualize_graphviz_widget(
         "graphviz_anywidget",
         "graphviz",
         reason="visualize_graphviz_widget",
-        extras="plotting",
+        extras="widgets",
     )
     from graphviz_anywidget import graphviz_widget
 


### PR DESCRIPTION
Probably the most sensible way to fix #984 by changing the required extra displayed in the error message to the one that includes the widget functionality.